### PR TITLE
Store precision matrix in CorrelationMatrixReconstructor

### DIFF
--- a/netrd/reconstruction/correlation_matrix.py
+++ b/netrd/reconstruction/correlation_matrix.py
@@ -47,11 +47,12 @@ class CorrelationMatrixReconstructor(BaseReconstructor):
         vals = vals[idx]
         vecs = vecs[:, idx]
 
-        # construct the precision matrix
+        # construct the precision matrix and store it
         P = (vecs[:, :num_eigs]) @\
             (1 / (vals[:num_eigs]).reshape(num_eigs, 1) * (vecs[:, :num_eigs]).T)
         P = P / (np.sqrt(np.diag(P)).reshape(num_sensors, 1) @\
                  np.sqrt(np.diag(P)).reshape(1, num_sensors))
+        self.results['matrix'] = P
 
         # threshold the precision matrix
         A = P * (P > np.percentile(P, quantile * 100))


### PR DESCRIPTION
For consistency with the template, store the precision matrix `P` prior to thresholding. The CorrelationMatrixReconstructor now stores two objects, the graph and the unthresholded matrix, in its `self.results`.