### PR TITLE
 Rename CorrelationMatrixReconstructor

### DIFF
--- a/netrd/reconstruction/__init__.py
+++ b/netrd/reconstruction/__init__.py
@@ -1,6 +1,6 @@
 from .base import BaseReconstructor
 from .random import RandomReconstructor
-from .correlation_matrix import CorrelationMatrixReconstructor
+from .regularized_correlation_matrix import RegluarizedCorrelationMatrixReconstructor
 from .free_energy_minimization import FreeEnergyMinimizationReconstructor
 from .naive_mean_field import NaiveMeanFieldReconstructor
 from .thouless_anderson_palmer import ThoulessAndersonPalmerReconstructor

--- a/netrd/reconstruction/__init__.py
+++ b/netrd/reconstruction/__init__.py
@@ -1,6 +1,6 @@
 from .base import BaseReconstructor
 from .random import RandomReconstructor
-from .regularized_correlation_matrix import RegluarizedCorrelationMatrixReconstructor
+from .regularized_correlation_matrix import RegularizedCorrelationMatrixReconstructor
 from .free_energy_minimization import FreeEnergyMinimizationReconstructor
 from .naive_mean_field import NaiveMeanFieldReconstructor
 from .thouless_anderson_palmer import ThoulessAndersonPalmerReconstructor

--- a/netrd/reconstruction/regularized_correlation_matrix.py
+++ b/netrd/reconstruction/regularized_correlation_matrix.py
@@ -14,7 +14,7 @@ import numpy as np
 import networkx as nx
 
 
-class RegluarizedCorrelationMatrixReconstructor(BaseReconstructor):
+class RegularizedCorrelationMatrixReconstructor(BaseReconstructor):
     def fit(self, TS, num_eigs=10, quantile=0.9):
         """
         Reconstruct a network from time series data using a regularized

--- a/netrd/reconstruction/regularized_correlation_matrix.py
+++ b/netrd/reconstruction/regularized_correlation_matrix.py
@@ -1,5 +1,5 @@
 """
-correlation_matrix.py
+regularized_correlation_matrix.py
 ---------------------
 
 Reconstruction of graphs using the correlation matrix.
@@ -14,7 +14,7 @@ import numpy as np
 import networkx as nx
 
 
-class CorrelationMatrixReconstructor(BaseReconstructor):
+class RegluarizedCorrelationMatrixReconstructor(BaseReconstructor):
     def fit(self, TS, num_eigs=10, quantile=0.9):
         """
         Reconstruct a network from time series data using a regularized


### PR DESCRIPTION
So that we can implement a similar method without regularization, rename
the current CorrelationMatrixReconstructor, which has regularization, to
RegluarizedCorrelationMatrixReconstructor