### PR TITLE
Changed nx.adjacency_matrix calls to nx.to_numpy_array so that functions consistently return dense adjacency matrices. Removed call to scipy.sparse.diags. 

### DIFF
--- a/netrd/distance/frobenius.py
+++ b/netrd/distance/frobenius.py
@@ -26,7 +26,7 @@ class Frobenius(BaseDistance):
         """Frobenius distance between two graphs."""
         adj1 = nx.to_numpy_array(G1)
         adj2 = nx.to_numpy_array(G2)
-        dist = np.linalg.norm((adj1 - adj2).A)
+        dist = np.linalg.norm((adj1 - adj2))
         self.results['dist'] = dist
         self.results['adj'] = np.array([adj1, adj2])
         return dist

--- a/netrd/distance/frobenius.py
+++ b/netrd/distance/frobenius.py
@@ -24,8 +24,8 @@ class Frobenius(BaseDistance):
 
     def dist(self, G1, G2):
         """Frobenius distance between two graphs."""
-        adj1 = nx.adjacency_matrix(G1)
-        adj2 = nx.adjacency_matrix(G2)
+        adj1 = nx.to_numpy_array(G1)
+        adj2 = nx.to_numpy_array(G2)
         dist = np.linalg.norm((adj1 - adj2).A)
         self.results['dist'] = dist
         self.results['adj'] = np.array([adj1, adj2])

--- a/netrd/distance/hamming.py
+++ b/netrd/distance/hamming.py
@@ -40,11 +40,11 @@ class Hamming(BaseDistance):
 
         """
 
-        adj1 = nx.adjacency_matrix(G1)
-        adj2 = nx.adjacency_matrix(G2)
+        adj1 = nx.to_numpy_array(G1)
+        adj2 = nx.to_numpy_array(G2)
         dist = scipy.spatial.distance.hamming(
-            adj1.toarray().flatten(), 
-            adj2.toarray().flatten()
+            adj1.flatten(), 
+            adj2.flatten()
         )
         self.results['dist'] = dist
         self.results['adj'] = np.array([adj1, adj2])

--- a/netrd/distance/jaccard_distance.py
+++ b/netrd/distance/jaccard_distance.py
@@ -37,8 +37,8 @@ class JaccardDistance(BaseDistance):
         dist (float): the distance between G1 and G2.
 
         """
-        adj1 = nx.to_numpy_matrix(G1)
-        adj2 = nx.to_numpy_matrix(G2)
+        adj1 = nx.to_numpy_array(G1)
+        adj2 = nx.to_numpy_array(G2)
         dist = 1 - jaccard_similarity_score(adj1,adj2)
         self.results['dist'] = float(dist)
         self.results['adj'] = np.array([adj1, adj2])

--- a/netrd/distance/portrait_divergence.py
+++ b/netrd/distance/portrait_divergence.py
@@ -286,8 +286,8 @@ class PortraitDivergence(BaseDistance):
         
         """
 
-        adj1 = nx.adjacency_matrix(G1)
-        adj2 = nx.adjacency_matrix(G2)
+        adj1 = nx.to_numpy_array(G1)
+        adj2 = nx.to_numpy_array(G2)
 
         paths_G1 = list(nx.all_pairs_dijkstra_path_length(G1))
         paths_G2 = list(nx.all_pairs_dijkstra_path_length(G2))

--- a/netrd/distance/resistance_perturbation.py
+++ b/netrd/distance/resistance_perturbation.py
@@ -80,9 +80,9 @@ def get_resistance_matrix(G):
     """
     # Get adjacency matrix
     n = len(G.nodes())
-    A = nx.adjacency_matrix(G)
+    A = nx.to_numpy_array(G)
     # Get Laplacian
-    D = ss.diags(np.squeeze(np.asarray(A.sum(axis=0))))
+    D = np.diag(A.sum(axis=0))
     L = D - A
     # Get Moore-Penrose pseudoinverses of Laplacian
     # Note: converts to dense matrix and introduces n^2 operation here


### PR DESCRIPTION
Addresses #46 