### PR TITLE
shorter test for naive transfer entropy reconstructor

### DIFF
--- a/tests/test_reconstruction.py
+++ b/tests/test_reconstruction.py
@@ -19,13 +19,28 @@ def test_graph_size():
     used to reconstruct the graph.
     """
     for label, obj in reconstruction.__dict__.items():
-        if label == 'PartialCorrelationMatrixReconstructor':
+        if label in [
+                'PartialCorrelationMatrixReconstructor',
+                'NaiveTransferEntropyReconstructor'
+        ]:
             continue
         if isinstance(obj, type) and BaseReconstructor in obj.__bases__:
             for size in [10, 100]:
                 TS = np.random.random((size, 250))
                 G = obj().fit(TS)
                 assert G.order() == size
+
+
+def test_naive_transfer_entropy():
+    """
+    Use a smaller data set to test the NaiveTransferEntropyReconstructor,
+    because it is very slow.
+
+    """
+    size = 50
+    TS = np.random.random((size, 100))
+    G = reconstruction.NaiveTransferEntropyReconstructor().fit(TS, delay_max=2)
+    assert G.order() == size
 
 
 def test_convergent_cross_mapping():
@@ -66,4 +81,3 @@ def test_partial_correlation():
                         assert G.order() == size
                     else:
                         assert G.order() == (size - 1)
-


### PR DESCRIPTION
Tests went from 2 minutes on Travis to 10 minutes after adding the naive transfer entropy method. This should push it back to ~2 minutes.