### PR TITLE
Enforce the use of `create_graph`

### DIFF
--- a/netrd/reconstruction/convergent_cross_mapping.py
+++ b/netrd/reconstruction/convergent_cross_mapping.py
@@ -16,6 +16,7 @@ from itertools import permutations
 from scipy.stats import pearsonr
 import networkx as nx
 from sklearn.neighbors import NearestNeighbors
+from ..utilities.graph import create_graph
 
 
 class ConvergentCrossMappingReconstructor(BaseReconstructor):
@@ -113,8 +114,7 @@ class ConvergentCrossMappingReconstructor(BaseReconstructor):
 
         # Build the reconstructed graph by finding significantly correlated
         # variables
-        G = nx.DiGraph(pvalue.T < alpha)
-        G.remove_edges_from(G.selfloop_edges())  # Filter out self-dependency
+        G = create_graph(pvalue.T < alpha, create_using=nx.DiGraph)
 
         # Save the graph object, matrices of correlation and p-values into the
         # "results" field (dictionary)

--- a/netrd/reconstruction/correlation_matrix.py
+++ b/netrd/reconstruction/correlation_matrix.py
@@ -12,6 +12,7 @@ Submitted as part of the 2019 NetSI Collabathon
 from .base import BaseReconstructor
 import numpy as np
 import networkx as nx
+from ..utilities.graph import create_graph
 
 
 class CorrelationMatrixReconstructor(BaseReconstructor):
@@ -46,7 +47,7 @@ class CorrelationMatrixReconstructor(BaseReconstructor):
         A = cor * mask
 
         # construct the network
-        self.results['graph'] = nx.from_numpy_array(A)
+        self.results['graph'] = create_graph(A)
         G = self.results['graph']
 
         return G

--- a/netrd/reconstruction/exact_mean_field.py
+++ b/netrd/reconstruction/exact_mean_field.py
@@ -13,6 +13,8 @@ import scipy as sp
 from scipy import linalg
 from scipy.integrate import quad
 from scipy.optimize import fsolve
+from ..utilities.graph import create_graph
+
 
 class ExactMeanFieldReconstructor(BaseReconstructor):
     def fit(self, TS, stop_criterion=True):
@@ -105,7 +107,8 @@ class ExactMeanFieldReconstructor(BaseReconstructor):
         W = W_EMF
 
         # construct the network
-        self.results['graph'] = nx.from_numpy_array(W)
+
+        self.results['graph'] = create_graph(W)
         self.results['matrix'] = W
         G = self.results['graph']
 

--- a/netrd/reconstruction/free_energy_minimization.py
+++ b/netrd/reconstruction/free_energy_minimization.py
@@ -11,6 +11,7 @@ import numpy as np
 import networkx as nx
 import scipy as sp
 from scipy import linalg
+from ..utilities.graph import create_graph
 
 
 class FreeEnergyMinimizationReconstructor(BaseReconstructor):
@@ -76,7 +77,7 @@ class FreeEnergyMinimizationReconstructor(BaseReconstructor):
             W[i0, :] = w[:]
 
         # construct the network
-        self.results['graph'] = nx.from_numpy_array(W)
+        self.results['graph'] = create_graph(W)
         self.results['matrix'] = W
         G = self.results['graph']
 

--- a/netrd/reconstruction/graphical_lasso.py
+++ b/netrd/reconstruction/graphical_lasso.py
@@ -17,6 +17,7 @@ import networkx as nx
 import numpy as np
 from sklearn.linear_model import lars_path
 from .base import BaseReconstructor
+from ..utilities.graph import create_graph
 
 
 class GraphicalLassoReconstructor(BaseReconstructor):
@@ -48,7 +49,7 @@ class GraphicalLassoReconstructor(BaseReconstructor):
         self.results['covariance'] = cov
         self.results['weights'] = cov
         self.results['precision'] = prec
-        G = nx.from_numpy_array(self.results["weights"])
+        G = create_graph(self.results['weights'])
         self.results['graph'] = G
 
         return G

--- a/netrd/reconstruction/marchenko_pastur.py
+++ b/netrd/reconstruction/marchenko_pastur.py
@@ -13,6 +13,8 @@ Submitted as part of the 2019 NetSI Collabathon.
 from .base import BaseReconstructor
 import numpy as np
 import networkx as nx
+from ..utilities.graph import create_graph
+
 
 class MarchenkoPastur(BaseReconstructor):
     def fit(self, TS, only_positive=True, remove_largest=False, metric_distance=False, 
@@ -150,7 +152,7 @@ class MarchenkoPastur(BaseReconstructor):
         if remove_selfloops:
             np.fill_diagonal(C_signal,0)
 
-        G = nx.from_numpy_array(C_signal)
+        G = create_graph(C_signal)
 
         self.results['graph'] = G
         return G

--- a/netrd/reconstruction/maximum_likelihood_estimation.py
+++ b/netrd/reconstruction/maximum_likelihood_estimation.py
@@ -9,6 +9,8 @@ submitted as part of the 2019 NeTSI Collabathon
 from .base import BaseReconstructor
 import numpy as np
 import networkx as nx
+from ..utilities.graph import create_graph
+
 
 class MaximumLikelihoodEstimationReconstructor(BaseReconstructor):
     def fit(self, TS, rate=1.0, stop_criterion=True):
@@ -59,7 +61,7 @@ class MaximumLikelihoodEstimationReconstructor(BaseReconstructor):
             W[i0,:] = w
 
         # construct the network
-        self.results['graph'] = nx.from_numpy_array(W)
+        self.results['graph'] = create_graph(W)
         self.results['matrix'] = W
         G = self.results['graph']
 

--- a/netrd/reconstruction/mutual_information_matrix.py
+++ b/netrd/reconstruction/mutual_information_matrix.py
@@ -15,6 +15,8 @@ Submitted as part of the 2019 NetSI Collabathon.
 from .base import BaseReconstructor
 import numpy as np
 import networkx as nx
+from ..utilities.graph import create_graph
+
 
 class MutualInformationMatrixReconstructor(BaseReconstructor):
     def fit(self, TS, deg=15, nbins=10):
@@ -59,7 +61,7 @@ class MutualInformationMatrixReconstructor(BaseReconstructor):
         tau=threshold_from_degree(deg,I)
         A = np.array(I>tau, dtype=int)
 
-        G = nx.from_numpy_matrix(A)
+        G = create_graph(A)
         self.results['G'] = G
 
         return G

--- a/netrd/reconstruction/naive_mean_field.py
+++ b/netrd/reconstruction/naive_mean_field.py
@@ -11,6 +11,8 @@ import numpy as np
 import networkx as nx
 import scipy as sp
 from scipy import linalg
+from ..utilities.graph import create_graph
+
 
 class NaiveMeanFieldReconstructor(BaseReconstructor):
     def fit(self, TS):
@@ -52,7 +54,7 @@ class NaiveMeanFieldReconstructor(BaseReconstructor):
         W = np.dot(A_inv, B)
 
         # construct the network
-        self.results['graph'] = nx.from_numpy_array(W)
+        self.results['graph'] = create_graph(W)
         self.results['matrix'] = W
         G = self.results['graph']
 

--- a/netrd/reconstruction/naive_transfer_entropy.py
+++ b/netrd/reconstruction/naive_transfer_entropy.py
@@ -16,6 +16,7 @@ import numpy as np
 import networkx as nx
 from scipy import stats
 from scipy import ndimage
+from ..utilities.graph import create_graph
 
 
 class NaiveTransferEntropyReconstructor(BaseReconstructor):
@@ -70,7 +71,7 @@ class NaiveTransferEntropyReconstructor(BaseReconstructor):
         A = np.array(TE > tau, dtype=int)
         self.results['adjacency_matrix'] = A
 
-        G = nx.from_numpy_matrix(A)
+        G = create_graph(A)
         self.results['G'] = G
 
         return G

--- a/netrd/reconstruction/ou_inference.py
+++ b/netrd/reconstruction/ou_inference.py
@@ -17,6 +17,8 @@ from .base import BaseReconstructor
 import networkx as nx
 import numpy as np
 from scipy.linalg import eig, inv
+from ..utilities.graph import create_graph
+
 
 class OUInferenceReconstructor(BaseReconstructor):
     def fit(self, TS):
@@ -49,7 +51,7 @@ class OUInferenceReconstructor(BaseReconstructor):
         self.results['weights'] = np.zeros([N, N]);
         self.results['weights'][index_pair] = weights;
 
-        G = nx.from_numpy_array(self.results['weights'])
+        G = create_graph(self.results['weights'])
         self.results['graph'] = G
 
         return G

--- a/netrd/reconstruction/partial_correlation_matrix.py
+++ b/netrd/reconstruction/partial_correlation_matrix.py
@@ -13,6 +13,7 @@ from .base import BaseReconstructor
 import numpy as np
 import networkx as nx
 from scipy import stats, linalg
+from ..utilities.graph import create_graph
 
 
 class PartialCorrelationMatrixReconstructor(BaseReconstructor):
@@ -66,7 +67,7 @@ class PartialCorrelationMatrixReconstructor(BaseReconstructor):
         A = p_cor * mask
 
         # construct the network
-        self.results['graph'] = nx.from_numpy_array(A)
+        self.results['graph'] = create_graph(A)
         G = self.results['graph']
 
         return G

--- a/netrd/reconstruction/regularized_correlation_matrix.py
+++ b/netrd/reconstruction/regularized_correlation_matrix.py
@@ -12,6 +12,7 @@ Submitted as part of the 2019 NetSI Collabathon
 from .base import BaseReconstructor
 import numpy as np
 import networkx as nx
+from ..utilities.graph import create_graph
 
 
 class RegularizedCorrelationMatrixReconstructor(BaseReconstructor):
@@ -63,7 +64,7 @@ class RegularizedCorrelationMatrixReconstructor(BaseReconstructor):
         A = P * (P > np.percentile(P, quantile * 100))
 
         # construct the network
-        self.results['graph'] = nx.from_numpy_array(A)
+        self.results['graph'] = create_graph(A)
         G = self.results['graph']
 
         return G

--- a/netrd/reconstruction/thouless_anderson_palmer.py
+++ b/netrd/reconstruction/thouless_anderson_palmer.py
@@ -12,6 +12,8 @@ import numpy as np
 import networkx as nx
 import scipy as sp
 from scipy import linalg
+from ..utilities.graph import create_graph
+
 
 class ThoulessAndersonPalmerReconstructor(BaseReconstructor):
     def fit(self, TS):
@@ -92,7 +94,7 @@ class ThoulessAndersonPalmerReconstructor(BaseReconstructor):
         W = np.dot(A_TAP_inv, B)
 
         # construct the network
-        self.results['graph'] = nx.from_numpy_array(W)
+        self.results['graph'] = create_graph(W)
         self.results['matrix'] = W
         G = self.results['graph']
 

--- a/netrd/reconstruction/time_granger_causality.py
+++ b/netrd/reconstruction/time_granger_causality.py
@@ -19,6 +19,8 @@ import numpy as np
 
 from .base import BaseReconstructor
 from sklearn.linear_model import LinearRegression
+from ..utilities.graph import create_graph
+
 
 class TimeGrangerCausalityReconstructor(BaseReconstructor):
     def fit(self, TS, lag=1):
@@ -58,7 +60,7 @@ class TimeGrangerCausalityReconstructor(BaseReconstructor):
                 self.results['weights'][j, i] = np.log(np.std(err1) / np.std(err2))
 
 
-        G = nx.from_numpy_array(self.results['weights'])
+        G = create_graph(self.results['weights'])
 
         self.results['graph'] = G
 

--- a/netrd/utilities/graph.py
+++ b/netrd/utilities/graph.py
@@ -35,9 +35,9 @@ def create_graph(A, create_using=None, remove_self_loops=True):
 
     if create_using is None:
         if np.allclose(A, A.T):
-            G = nx.from_numpy_array(G, create_using=nx.Graph)
+            G = nx.from_numpy_array(A, create_using=nx.Graph)
         else:
-            G = nx.from_numpy_array(G, create_using=nx.DiGraph)
+            G = nx.from_numpy_array(A, create_using=nx.DiGraph)
     else:
         G = nx.from_numpy_array(A, create_using=create_using)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-networkx>=2.0.0
+networkx>=2.2.0
 numpy>=1.10.0
 scipy>=1.0.0
 scikit-learn>=0.18.2


### PR DESCRIPTION
Resolves #78 by enforcing the use of `create_graph` in the reconstructors. This is a pretty sweeping change and should definitely be reviewed before merge.