### PR TITLE
backwards compatibility in create_graph

### DIFF
--- a/netrd/reconstruction/convergent_cross_mapping.py
+++ b/netrd/reconstruction/convergent_cross_mapping.py
@@ -114,7 +114,7 @@ class ConvergentCrossMappingReconstructor(BaseReconstructor):
 
         # Build the reconstructed graph by finding significantly correlated
         # variables
-        G = create_graph(pvalue.T < alpha, create_using=nx.DiGraph)
+        G = create_graph(pvalue.T < alpha, create_using=nx.DiGraph())
 
         # Save the graph object, matrices of correlation and p-values into the
         # "results" field (dictionary)

--- a/netrd/reconstruction/optimal_causation_entropy.py
+++ b/netrd/reconstruction/optimal_causation_entropy.py
@@ -88,7 +88,7 @@ class OptimalCausationEntropyReconstructor(BaseReconstructor):
 
         # Build the reconstructed graph
         A = nx.to_numpy_array(nx.DiGraph(adjlist).reverse())
-        G = create_graph(A, create_using=nx.DiGraph, remove_self_loops=False)
+        G = create_graph(A, create_using=nx.DiGraph(), remove_self_loops=False)
         self.results['graph'] = G
         self.results['parents'] = adjlist
 

--- a/netrd/utilities/graph.py
+++ b/netrd/utilities/graph.py
@@ -35,9 +35,9 @@ def create_graph(A, create_using=None, remove_self_loops=True):
 
     if create_using is None:
         if np.allclose(A, A.T):
-            G = nx.from_numpy_array(A, create_using=nx.Graph)
+            G = nx.from_numpy_array(A, create_using=nx.Graph())
         else:
-            G = nx.from_numpy_array(A, create_using=nx.DiGraph)
+            G = nx.from_numpy_array(A, create_using=nx.DiGraph())
     else:
         G = nx.from_numpy_array(A, create_using=create_using)
 


### PR DESCRIPTION
Prefer using the form `create_using=nx.Graph()` to `create_using=nx.Graph` for
backward compatibility with networkx 2.1.