### PR TITLE
Add checks.py with ensure_undirected function

### DIFF
--- a/netrd/distance/resistance_perturbation.py
+++ b/netrd/distance/resistance_perturbation.py
@@ -13,6 +13,7 @@ import numpy as np
 import networkx as nx
 import scipy.sparse as ss
 from .base import BaseDistance
+from ..utilities import ensure_undirected
 
 class ResistancePerturbation(BaseDistance):
     def dist(self, G1, G2, p=2):
@@ -55,16 +56,8 @@ class ResistancePerturbation(BaseDistance):
 
 
         # Coerce to undirected, if needed.
-        directed_flag = False
-        if nx.is_directed(G1):
-            G1 = nx.to_undirected(G1)
-            directed_flag = True
-        if nx.is_directed(G2):
-            G2 = nx.to_undirected(G2)
-            directed_flag = True
-
-        if directed_flag:
-            warnings.warn("Coercing directed graph to undirected.", RuntimeWarning)
+        G1 = ensure_undirected(G1)
+        G2 = ensure_undirected(G2)
 
         # Get resistance matrices
         R1 = get_resistance_matrix(G1)

--- a/netrd/utilities/__init__.py
+++ b/netrd/utilities/__init__.py
@@ -1,7 +1,8 @@
 from .threshold import threshold
-from .graph import create_graph
+from .graph import *
 from .read import *
 from .cluster import *
 from .standardize import *
+from .checks import *
 
 __all__ = []

--- a/netrd/utilities/checks.py
+++ b/netrd/utilities/checks.py
@@ -1,0 +1,38 @@
+"""
+checks.py
+------------
+
+Utilities for "type checking"
+
+author: Tim LaRock
+email: timothylarock at gmail dot com
+Submitted as part of the 2019 NetSI Collabathon
+
+"""
+
+import warnings
+import networkx as nx
+
+def ensure_undirected(G):
+    '''
+    Ensure the graph G is undirected. If it is not, coerce it to undirected
+    and warn the user.
+
+    Params
+    ------
+
+    G (networkx graph): The graph to be checked
+
+    Returns
+    -------
+
+    G (networkx graph): Undirected version of the input graph
+
+    '''
+
+    if nx.is_directed(G):
+        G = nx.to_undirected(G)
+        warnings.warn("Coercing directed graph to undirected.", RuntimeWarning)
+
+    return G
+


### PR DESCRIPTION
Some methods require an undirected network. This PR adds a utility function, `utilities.ensure_undirected(G)`, that checks whether an input `networkx` graph is directed. If it is, the network is coerced using `DiGraph.to_undirected()`, and a warning is raised to tell the user this is happening. If it is already undirected, the object is returned as is.

One potential point of confusion could be someone not reading the docstring and trying to use this to test an adjacency matrix for symmetry. `networkx` will throw an error if they do this, but just want to note that we may want to have similar functionality for adjacency matrices in the future. 