### PR TITLE
refactor standardize.py

### DIFF
--- a/netrd/utilities/standardize.py
+++ b/netrd/utilities/standardize.py
@@ -50,10 +50,12 @@ def mean_GNP_distance(n, prob, distance, samples=10, **kwargs):
 
     '''
     graphs = [nx.fast_gnp_random_graph(n, prob) for _ in range(samples)]
-    dis_mat = np.zeros((samples, samples))
+    dis_mat = np.full((samples, samples), np.nan)
     for i in range(samples):
-        for j in range(i+1, samples):
+        for j in range(samples):
+            if i == j:
+                continue
             dis_mat[i, j] = distance(graphs[i], graphs[j], **kwargs)
-    dis_mat += dis_mat.T
 
-    return dis_mat.mean(), dis_mat.std(), dis_mat
+    # the nan* versions below ignore NaNs and normalize appropriately
+    return np.nanmean(dis_mat), np.nanstd(dis_mat), dis_mat

--- a/netrd/utilities/standardize.py
+++ b/netrd/utilities/standardize.py
@@ -13,23 +13,23 @@ Submitted as part of the 2019 NetSI Collabathon
 import numpy as np
 import networkx as nx
 
-def mean_GNP_distance(n, edge_probability, distance, samples=10, **kwargs):
+def mean_GNP_distance(n, prob, distance, samples=10, **kwargs):
     '''
     Compute the mean distance between _samples_ GNP graphs with
-    parameters N=n,p=edge_probability using distance function _distance_,
+    parameters N=n,p=prob using distance function _distance_,
     whose parameters are passed with **kwargs.
 
     NOTE: Ideally, each 'sample' would involve generating two GNP graphs,
     computing the distance between them, then throwing them both away.
     However, this will be computationally expensive, so for now we are
-    reusing samples, but _not_ including distance between the same sample
-    in the mean (e.g. excluding the diagonal of a distance matrix).
+    reusing samples. The diagonal of the distance matrix is excluded, i.e.,
+    do not compute the distance between a sample graph and itself.
 
     Params
     ------
 
     n (int): Number of nodes in ER graphs to be generated
-    edge_probability (float): Probability of edge in ER graphs to be generated.
+    edge_prob (float): Probability of edge in ER graphs to be generated.
     samples (int): Number of samples to average distance over.
     distance (function): Function from netrd.distances.<distance>.dist
     kwargs (dict): Keyword arguments to pass to the distance function.
@@ -49,24 +49,11 @@ def mean_GNP_distance(n, edge_probability, distance, samples=10, **kwargs):
     mean, std, dists = netrd.utilities.mean_GNP_distance(100, 0.1, dist_obj.dist, **kwargs)
 
     '''
-    # generate sample graphs
-    a=[]
-    for _ in range(samples):
-       a.append(nx.fast_gnp_random_graph(n, edge_probability))
-
-    # get distances
-    dis_mat = np.zeros((samples,samples))
-    dis_list = []
+    graphs = [nx.fast_gnp_random_graph(n, prob) for _ in range(samples)]
+    dis_mat = np.zeros((samples, samples))
     for i in range(samples):
-        for j in range(samples):
-            # Do not compute distance between identical samples (see docstring)
-            if i != j:
-                dis[i,j]= distance(a[i], a[j], **kwargs)
-                dis_list.append(dis[i,j])
+        for j in range(i+1, samples):
+            dis_mat[i, j] = distance(graphs[i], graphs[j], **kwargs)
+    dis_mat += dis_mat.T
 
-    # get mean distances \ std distances
-    mean_dist=np.mean(dis_list)
-    std_dist=np.std(dis_list)
-
-    return mean_dist, std_dist, dis_mat
-
+    return dis_mat.mean(), dis_mat.std(), dis_mat


### PR DESCRIPTION
A couple of things are included in this PR:
1. The `dis_list` variable was not needed as it was only used to compute mean and standard deviation, which can be done directly from `dis_mat`.
2. There was a typo in line 64, where `dis` was used instead of `dis_mat`.
3. Changed `edge_probability` to `prob` for the sake of shorter lines.
3. IMPORTANT: Computation time can be halved if we assume that all distance functions are symmetric. In that case, we need only compute the upper triangular entries of `dis_mat`. However, this is conditioned on all distances in `netrd/distances` being symmetric. *Are we sure they all are?*