### PR TITLE
Resolve IntegrationWarning in test for Ipsen-Mikhailov

### DIFF
--- a/netrd/distance/ipsen_mikhailov.py
+++ b/netrd/distance/ipsen_mikhailov.py
@@ -99,5 +99,5 @@ def _im_distance(adj1, adj2, hwhm):
 
     func = lambda w: (density1(w) - density2(w))**2
 
-    return np.sqrt(quad(func, 0, np.inf)[0])
+    return np.sqrt(quad(func, 0, np.inf, limit = 100)[0])
 


### PR DESCRIPTION
Increase the number of subdivisions to ensure that the integral is found in IM distance.