### PR TITLE
Fix incorrect ValueError message in partial_corr

### DIFF
--- a/netrd/reconstruction/partial_correlation_influence.py
+++ b/netrd/reconstruction/partial_correlation_influence.py
@@ -176,7 +176,7 @@ def partial_corr(C, index=None):
                 idx[index] = True
             else:
                 raise ValueError("Index must be an integer, an array of "
-                                 "integers, or False.")
+                                 "integers, or None.")
 
             beta_i = linalg.lstsq(C[:, idx], C[:, j])[0]
             beta_j = linalg.lstsq(C[:, idx], C[:, i])[0]

--- a/netrd/reconstruction/partial_correlation_matrix.py
+++ b/netrd/reconstruction/partial_correlation_matrix.py
@@ -143,7 +143,7 @@ def partial_corr(C, index=None):
                 idx[index] = True
             else:
                 raise ValueError("Index must be an integer, an array of "
-                                 "integers, or False.")
+                                 "integers, or None.")
 
             beta_i = linalg.lstsq(C[:, idx], C[:, j])[0]
             beta_j = linalg.lstsq(C[:, idx], C[:, i])[0]


### PR DESCRIPTION
We expect `index` to be `int`s or `None`, not `ints` or `False`, as shown by the `if index is None` conditional. Very minor change; should be straightforward to merge.