### PR TITLE
Address self-loops when thresholding

### DIFF
--- a/netrd/utilities/threshold.py
+++ b/netrd/utilities/threshold.py
@@ -121,13 +121,13 @@ def threshold_on_degree(mat, **kwargs):
         np.fill_diagonal(A, 0)
         np.fill_diagonal(mat, 0)
 
-    if np.mean(np.sum(A, 1)) <= 2*avg_k:
+    if np.mean(np.sum(A, 1)) <= avg_k:
         # degenerate case: threshold the whole matrix
         thresholded_mat = mat
     else:
         for m in sorted(mat.flatten()):
             A[mat == m] = 0
-            if np.mean(np.sum(A, 1)) <= 2*avg_k:
+            if np.mean(np.sum(A, 1)) <= avg_k:
                 break
         thresholded_mat = mat * (mat > m)
 

--- a/netrd/utilities/threshold.py
+++ b/netrd/utilities/threshold.py
@@ -44,8 +44,11 @@ def threshold_in_range(mat, **kwargs):
 
     thresholded_mat = mat * mask
 
-    if 'binary' in kwargs and kwargs['binary']:
+    if kwargs.get('binary', False):
         thresholded_mat = np.abs(np.sign(thresholded_mat))
+
+    if kwargs.get('remove_self_loops', False):
+        np.fill_diagonal(thresholded_mat, 0)
 
     return thresholded_mat
 
@@ -73,12 +76,15 @@ def threshold_on_quantile(mat, **kwargs):
             RuntimeWarning)
         quantile = 0.9
 
+    if kwargs.get('remove_self_loops', False):
+        np.fill_diagonal(A, 0)
+
     if quantile != 0:
         thresholded_mat = mat * (mat > np.percentile(mat, quantile * 100))
     else:
         thresholded_mat = mat
 
-    if 'binary' in kwargs and kwargs['binary']:
+    if kwargs.get('binary', False):
         thresholded_mat = np.abs(np.sign(thresholded_mat))
 
     return thresholded_mat
@@ -103,24 +109,29 @@ def threshold_on_degree(mat, **kwargs):
         avg_k = kwargs['avg_k']
     else:
         warnings.warn(
-            "Setting 'avg_k' argument is strongly encouraged. Using average degree of 1 for thresholding.",
+            "Setting 'avg_k' argument is strongly encouraged. Using average "
+            "degree of 1 for thresholding.",
             RuntimeWarning)
         avg_k = 1
 
     n = len(mat)
     A = np.ones((n, n))
 
-    if np.mean(np.sum(A, 1)) <= avg_k:
+    if kwargs.get('remove_self_loops', False):
+        np.fill_diagonal(A, 0)
+        np.fill_diagonal(mat, 0)
+
+    if np.mean(np.sum(A, 1)) <= 2*avg_k:
         # degenerate case: threshold the whole matrix
         thresholded_mat = mat
     else:
         for m in sorted(mat.flatten()):
             A[mat == m] = 0
-            if np.mean(np.sum(A, 1)) <= avg_k:
+            if np.mean(np.sum(A, 1)) <= 2*avg_k:
                 break
         thresholded_mat = mat * (mat > m)
 
-    if 'binary' in kwargs and kwargs['binary']:
+    if kwargs.get('binary', False):
         thresholded_mat = np.abs(np.sign(thresholded_mat))
 
     return thresholded_mat


### PR DESCRIPTION
Inspired by the discussion in #54. When thresholding on a quantile or average
degree, the diagonal of the weights matrix was being used in the calculation of
the quantile or average degree, even when those self-loops were destined to be
removed by the `create_graph` function. This PR adds a `remove_self_loops`
parameter, passed through `kwargs`, to zero out the weights matrix when
appropriate.

Additionally, this PR uses `2*avg_k` in `threshold_on_degree` to better fit intuition. This could be a separate PR or issue, I can revert if needed.
