### PR TITLE
Naming changes (CODE BREAKING COMMIT)

### DIFF
--- a/doc/source/distance.rst
+++ b/doc/source/distance.rst
@@ -26,8 +26,8 @@ same general usage as above.
     netrd.distance.HammingIpsenMikhailov
     netrd.distance.IpsenMikhailov
     netrd.distance.JaccardDistance
-    netrd.distance.LaplacianSpectralMethod
-    netrd.distance.NBD
+    netrd.distance.LaplacianSpectral
+    netrd.distance.NonBacktrackingSpectral
     netrd.distance.NetLSD
     netrd.distance.NetSimile
     netrd.distance.OnionDivergence

--- a/doc/source/reconstruction.rst
+++ b/doc/source/reconstruction.rst
@@ -18,23 +18,23 @@ the same general usage as above.
 .. autosummary::
    :nosignatures:
 
-    netrd.reconstruction.ConvergentCrossMappingReconstructor
-    netrd.reconstruction.CorrelationMatrixReconstructor
+    netrd.reconstruction.ConvergentCrossMapping
+    netrd.reconstruction.CorrelationMatrix
     netrd.reconstruction.CorrelationSpanningTree
-    netrd.reconstruction.FreeEnergyMinimizationReconstructor
-    netrd.reconstruction.GraphicalLassoReconstructor
+    netrd.reconstruction.FreeEnergyMinimization
+    netrd.reconstruction.GraphicalLasso
     netrd.reconstruction.MarchenkoPastur
-    netrd.reconstruction.MaximumLikelihoodEstimationReconstructor
-    netrd.reconstruction.MeanFieldReconstructor
-    netrd.reconstruction.MutualInformationMatrixReconstructor
-    netrd.reconstruction.NaiveTransferEntropyReconstructor
-    netrd.reconstruction.OUInferenceReconstructor
-    netrd.reconstruction.OptimalCausationEntropyReconstructor
-    netrd.reconstruction.PartialCorrelationInfluenceReconstructor
-    netrd.reconstruction.PartialCorrelationMatrixReconstructor
+    netrd.reconstruction.MaximumLikelihoodEstimation
+    netrd.reconstruction.MeanField
+    netrd.reconstruction.MutualInformationMatrix
+    netrd.reconstruction.NaiveTransferEntropy
+    netrd.reconstruction.OUInference
+    netrd.reconstruction.OptimalCausationEntropy
+    netrd.reconstruction.PartialCorrelationInfluence
+    netrd.reconstruction.PartialCorrelationMatrix
     netrd.reconstruction.RandomReconstructor
-    netrd.reconstruction.ThoulessAndersonPalmerReconstructor
-    netrd.reconstruction.TimeGrangerCausalityReconstructor
+    netrd.reconstruction.ThoulessAndersonPalmer
+    netrd.reconstruction.TimeGrangerCausality
 
 
 Reference

--- a/netrd/distance/__init__.py
+++ b/netrd/distance/__init__.py
@@ -8,9 +8,9 @@ from .hamming_ipsen_mikhailov import HammingIpsenMikhailov
 from .resistance_perturbation import ResistancePerturbation
 from .netsimile import NetSimile
 from .netlsd import NetLSD
-from .laplacian_spectral_method import LaplacianSpectralMethod
+from .laplacian_spectral_method import LaplacianSpectral
 from .polynomial_dissimilarity import PolynomialDissimilarity
-from .nbd import NBD
+from .nbd import NonBacktrackingSpectral
 from .degree_divergence import DegreeDivergence
 from .onion_divergence import OnionDivergence
 from .deltacon import DeltaCon
@@ -29,9 +29,9 @@ __all__ = [
     'ResistancePerturbation',
     'NetSimile',
     'NetLSD',
-    'LaplacianSpectralMethod',
+    'LaplacianSpectral',
     'PolynomialDissimilarity',
-    'NBD',
+    'NonBacktrackingSpectral',
     'DegreeDivergence',
     'OnionDivergence',
     'DeltaCon',

--- a/netrd/distance/laplacian_spectral_method.py
+++ b/netrd/distance/laplacian_spectral_method.py
@@ -23,7 +23,7 @@ from scipy.sparse.csgraph import laplacian
 from scipy.sparse.linalg import eigsh
 
 
-class LaplacianSpectralMethod(BaseDistance):
+class LaplacianSpectral(BaseDistance):
     """Flexible distance able to compare the spectrum of the Laplacian in many ways."""
 
     def dist(
@@ -98,17 +98,18 @@ class LaplacianSpectralMethod(BaseDistance):
         dist (float)
             the distance between G1 and G2.
 
+        Notes
+        -----
+        The methods are usually applied to undirected (unweighted)
+        networks. We however relax this assumption using the same method
+        proposed for the Hamming-Ipsen-Mikhailov. See [2]_.
+
         References
         ----------
 
         .. [1] https://www.sciencedirect.com/science/article/pii/S0303264711001869.
 
-        Notes
-        -----
-        The methods are usually applied to undirected (unweighted)
-        networks. We however relax this assumption using the same method
-        proposed for the Hamming-Ipsen-Mikhailov. See paper:
-        https://ieeexplore.ieee.org/abstract/document/7344816.
+        .. [2] https://ieeexplore.ieee.org/abstract/document/7344816.
 
         """
         adj1 = nx.to_numpy_array(G1)

--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -14,7 +14,7 @@ from ot import emd2
 from .base import BaseDistance
 
 
-class NBD(BaseDistance):
+class NonBacktrackingSpectral(BaseDistance):
     """Compares the empirical spectral distribution of the non-backtracking
 matrices.
 

--- a/netrd/reconstruction/__init__.py
+++ b/netrd/reconstruction/__init__.py
@@ -1,38 +1,38 @@
 from .base import BaseReconstructor
 from .random import RandomReconstructor
-from .correlation_matrix import CorrelationMatrixReconstructor
-from .partial_correlation_matrix import PartialCorrelationMatrixReconstructor
-from .partial_correlation_influence import PartialCorrelationInfluenceReconstructor
-from .free_energy_minimization import FreeEnergyMinimizationReconstructor
-from .mean_field import MeanFieldReconstructor
-from .thouless_anderson_palmer import ThoulessAndersonPalmerReconstructor
-from .maximum_likelihood_estimation import MaximumLikelihoodEstimationReconstructor
-from .convergent_cross_mapping import ConvergentCrossMappingReconstructor
-from .mutual_information_matrix import MutualInformationMatrixReconstructor
-from .ou_inference import OUInferenceReconstructor
-from .graphical_lasso import GraphicalLassoReconstructor
+from .correlation_matrix import CorrelationMatrix
+from .partial_correlation_matrix import PartialCorrelationMatrix
+from .partial_correlation_influence import PartialCorrelationInfluence
+from .free_energy_minimization import FreeEnergyMinimization
+from .mean_field import MeanField
+from .thouless_anderson_palmer import ThoulessAndersonPalmer
+from .maximum_likelihood_estimation import MaximumLikelihoodEstimation
+from .convergent_cross_mapping import ConvergentCrossMapping
+from .mutual_information_matrix import MutualInformationMatrix
+from .ou_inference import OUInference
+from .graphical_lasso import GraphicalLasso
 from .marchenko_pastur import MarchenkoPastur
-from .naive_transfer_entropy import NaiveTransferEntropyReconstructor
-from .time_granger_causality import TimeGrangerCausalityReconstructor
-from .optimal_causation_entropy import OptimalCausationEntropyReconstructor
+from .naive_transfer_entropy import NaiveTransferEntropy
+from .time_granger_causality import TimeGrangerCausality
+from .optimal_causation_entropy import OptimalCausationEntropy
 from .correlation_spanning_tree import CorrelationSpanningTree
 
 __all__ = [
     'RandomReconstructor',
-    'CorrelationMatrixReconstructor',
-    'PartialCorrelationMatrixReconstructor',
-    'PartialCorrelationInfluenceReconstructor',
-    'FreeEnergyMinimizationReconstructor',
-    'ThoulessAndersonPalmerReconstructor',
-    'MeanFieldReconstructor',
-    'MaximumLikelihoodEstimationReconstructor',
-    'ConvergentCrossMappingReconstructor',
-    'MutualInformationMatrixReconstructor',
-    'OUInferenceReconstructor',
-    'GraphicalLassoReconstructor',
+    'CorrelationMatrix',
+    'PartialCorrelationMatrix',
+    'PartialCorrelationInfluence',
+    'FreeEnergyMinimization',
+    'ThoulessAndersonPalmer',
+    'MeanField',
+    'MaximumLikelihoodEstimation',
+    'ConvergentCrossMapping',
+    'MutualInformationMatrix',
+    'OUInference',
+    'GraphicalLasso',
     'MarchenkoPastur',
-    'NaiveTransferEntropyReconstructor',
-    'TimeGrangerCausalityReconstructor',
-    'OptimalCausationEntropyReconstructor',
+    'NaiveTransferEntropy',
+    'TimeGrangerCausality',
+    'OptimalCausationEntropy',
     'CorrelationSpanningTree',
 ]

--- a/netrd/reconstruction/convergent_cross_mapping.py
+++ b/netrd/reconstruction/convergent_cross_mapping.py
@@ -19,7 +19,7 @@ from sklearn.neighbors import NearestNeighbors
 from ..utilities import create_graph, threshold
 
 
-class ConvergentCrossMappingReconstructor(BaseReconstructor):
+class ConvergentCrossMapping(BaseReconstructor):
     """Infers dynamical causal relations."""
 
     def fit(

--- a/netrd/reconstruction/correlation_matrix.py
+++ b/netrd/reconstruction/correlation_matrix.py
@@ -12,7 +12,7 @@ import networkx as nx
 from ..utilities import create_graph, threshold
 
 
-class CorrelationMatrixReconstructor(BaseReconstructor):
+class CorrelationMatrix(BaseReconstructor):
     """Uses the correlation matrix."""
 
     def fit(self, TS, num_eigs=None, threshold_type='range', **kwargs):

--- a/netrd/reconstruction/correlation_spanning_tree.py
+++ b/netrd/reconstruction/correlation_spanning_tree.py
@@ -1,6 +1,6 @@
 """
 correlation_spanning_tree.py
---------------
+----------------------------
 
 Graph reconstruction algorithm based on Mantegna, R. N. (1999). Hierarchical structure in
 financial markets. The European Physical Journal B-Condensed Matter and Complex Systems,

--- a/netrd/reconstruction/free_energy_minimization.py
+++ b/netrd/reconstruction/free_energy_minimization.py
@@ -14,7 +14,7 @@ from scipy import linalg
 from ..utilities import create_graph, threshold
 
 
-class FreeEnergyMinimizationReconstructor(BaseReconstructor):
+class FreeEnergyMinimization(BaseReconstructor):
     """Applies free energy principle."""
 
     def fit(self, TS, threshold_type='degree', **kwargs):

--- a/netrd/reconstruction/graphical_lasso.py
+++ b/netrd/reconstruction/graphical_lasso.py
@@ -20,7 +20,7 @@ from .base import BaseReconstructor
 from ..utilities import create_graph, threshold
 
 
-class GraphicalLassoReconstructor(BaseReconstructor):
+class GraphicalLasso(BaseReconstructor):
     """Performs graphical lasso."""
 
     def fit(

--- a/netrd/reconstruction/maximum_likelihood_estimation.py
+++ b/netrd/reconstruction/maximum_likelihood_estimation.py
@@ -12,7 +12,7 @@ import networkx as nx
 from ..utilities import create_graph, threshold
 
 
-class MaximumLikelihoodEstimationReconstructor(BaseReconstructor):
+class MaximumLikelihoodEstimation(BaseReconstructor):
     """Uses maximum likelihood estimation."""
 
     def fit(self, TS, rate=1.0, stop_criterion=True, threshold_type='degree', **kwargs):

--- a/netrd/reconstruction/mean_field.py
+++ b/netrd/reconstruction/mean_field.py
@@ -16,7 +16,7 @@ from scipy.optimize import fsolve
 from ..utilities import create_graph, threshold
 
 
-class MeanFieldReconstructor(BaseReconstructor):
+class MeanField(BaseReconstructor):
     def fit(
         self, TS, exact=True, stop_criterion=True, threshold_type='range', **kwargs
     ):

--- a/netrd/reconstruction/mutual_information_matrix.py
+++ b/netrd/reconstruction/mutual_information_matrix.py
@@ -18,7 +18,7 @@ import networkx as nx
 from ..utilities import create_graph, threshold
 
 
-class MutualInformationMatrixReconstructor(BaseReconstructor):
+class MutualInformationMatrix(BaseReconstructor):
     """Uses the mutual information between nodes."""
 
     def fit(self, TS, nbins=10, threshold_type='degree', **kwargs):

--- a/netrd/reconstruction/naive_transfer_entropy.py
+++ b/netrd/reconstruction/naive_transfer_entropy.py
@@ -19,7 +19,7 @@ from scipy import ndimage
 from ..utilities import create_graph, threshold
 
 
-class NaiveTransferEntropyReconstructor(BaseReconstructor):
+class NaiveTransferEntropy(BaseReconstructor):
     """Uses transfer entropy between sensors."""
 
     def fit(self, TS, delay_max=10, threshold_type='range', **kwargs):

--- a/netrd/reconstruction/optimal_causation_entropy.py
+++ b/netrd/reconstruction/optimal_causation_entropy.py
@@ -16,7 +16,7 @@ import numpy as np
 from ..utilities import create_graph
 
 
-class OptimalCausationEntropyReconstructor(BaseReconstructor):
+class OptimalCausationEntropy(BaseReconstructor):
     """Optimizes causation entropy."""
 
     def fit(self, TS, n_bins=40, atol=1e-6, **kwargs):

--- a/netrd/reconstruction/ou_inference.py
+++ b/netrd/reconstruction/ou_inference.py
@@ -20,7 +20,7 @@ from scipy.linalg import eig, inv
 from ..utilities import create_graph, threshold
 
 
-class OUInferenceReconstructor(BaseReconstructor):
+class OUInference(BaseReconstructor):
     """Assumes a Orstein-Uhlenbeck generative model."""
 
     def fit(self, TS, threshold_type='range', **kwargs):

--- a/netrd/reconstruction/partial_correlation_influence.py
+++ b/netrd/reconstruction/partial_correlation_influence.py
@@ -24,7 +24,7 @@ from scipy import stats, linalg
 from ..utilities import create_graph, threshold
 
 
-class PartialCorrelationInfluenceReconstructor(BaseReconstructor):
+class PartialCorrelationInfluence(BaseReconstructor):
     """Uses average effect from a sensor to all others."""
 
     def fit(self, TS, index=None, threshold_type='range', **kwargs):

--- a/netrd/reconstruction/partial_correlation_matrix.py
+++ b/netrd/reconstruction/partial_correlation_matrix.py
@@ -16,7 +16,7 @@ from scipy import stats, linalg
 from ..utilities import create_graph, threshold
 
 
-class PartialCorrelationMatrixReconstructor(BaseReconstructor):
+class PartialCorrelationMatrix(BaseReconstructor):
     """Uses a regularized form of the precision matrix."""
 
     def fit(

--- a/netrd/reconstruction/thouless_anderson_palmer.py
+++ b/netrd/reconstruction/thouless_anderson_palmer.py
@@ -15,7 +15,7 @@ from scipy import linalg
 from ..utilities import create_graph, threshold
 
 
-class ThoulessAndersonPalmerReconstructor(BaseReconstructor):
+class ThoulessAndersonPalmer(BaseReconstructor):
     """Uses Thouless-Anderson-Palmer mean field approximation."""
 
     def fit(self, TS, threshold_type='range', **kwargs):

--- a/netrd/reconstruction/time_granger_causality.py
+++ b/netrd/reconstruction/time_granger_causality.py
@@ -22,7 +22,7 @@ from sklearn.linear_model import LinearRegression
 from ..utilities import create_graph, threshold
 
 
-class TimeGrangerCausalityReconstructor(BaseReconstructor):
+class TimeGrangerCausality(BaseReconstructor):
     """Infers Granger causality."""
 
     def fit(self, TS, lag=1, threshold_type='range', **kwargs):

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -42,12 +42,11 @@ def test_different_graphs():
 
 def test_symmetry():
     """The distance between two graphs must be symmetric."""
-
     G1 = nx.barabasi_albert_graph(100, 4)
     G2 = nx.fast_gnp_random_graph(100, 0.1)
 
     for label, obj in distance.__dict__.items():
-        if label in ['NBD']:
+        if label in ['NonBacktrackingSpectral']:
             continue
         if isinstance(obj, type) and BaseDistance in obj.__bases__:
             dist1 = obj().dist(G1, G2)

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -18,7 +18,7 @@ def test_same_graph():
     G = nx.karate_club_graph()
 
     for label, obj in distance.__dict__.items():
-        if label in ['NBD']:
+        if label in ['NonBacktrackingSpectral']:
             continue
         if isinstance(obj, type) and BaseDistance in obj.__bases__:
             dist = obj().dist(G, G)

--- a/tests/test_reconstruction.py
+++ b/tests/test_reconstruction.py
@@ -8,7 +8,7 @@ Test reconstruction algorithms.
 
 import numpy as np
 from netrd import reconstruction
-from netrd.reconstruction import ConvergentCrossMappingReconstructor
+from netrd.reconstruction import ConvergentCrossMapping
 from netrd.reconstruction import BaseReconstructor
 
 
@@ -21,8 +21,8 @@ def test_graph_size():
     size = 50
     for label, obj in reconstruction.__dict__.items():
         if label in [
-            'PartialCorrelationMatrixReconstructor',
-            'NaiveTransferEntropyReconstructor' 'OptimalCausationEntropyReconstructor',
+            'PartialCorrelationMatrix',
+            'NaiveTransferEntropy' 'OptimalCausationEntropy',
         ]:
             continue
         if isinstance(obj, type) and BaseReconstructor in obj.__bases__:
@@ -33,13 +33,13 @@ def test_graph_size():
 
 def test_naive_transfer_entropy():
     """
-    Use a smaller data set to test the NaiveTransferEntropyReconstructor,
+    Use a smaller data set to test the NaiveTransferEntropy,
     because it is very slow.
 
     """
     size = 25
     TS = np.random.random((size, 100))
-    G = reconstruction.NaiveTransferEntropyReconstructor().fit(
+    G = reconstruction.NaiveTransferEntropy().fit(
         TS, delay_max=2, threshold_type='range', cutoffs=[(-np.inf, np.inf)]
     )
     assert G.order() == size
@@ -52,7 +52,7 @@ def test_oce():
 
     size = 25
     TS = np.random.random((size, 50))
-    G = reconstruction.OptimalCausationEntropyReconstructor().fit(
+    G = reconstruction.OptimalCausationEntropy().fit(
         TS, threshold_type='range', cutoffs=[(-np.inf, np.inf)]
     )
     assert G.order() == size
@@ -60,7 +60,7 @@ def test_oce():
 
 def test_convergent_cross_mapping():
     """
-    Examine the outcome of ConvergentCrossMappingReconstructor with synthetic
+    Examine the outcome of ConvergentCrossMapping with synthetic
     time series data generated from a two-species Lotka-Vottera model.
 
     """
@@ -69,7 +69,7 @@ def test_convergent_cross_mapping():
     keys = ['graph', 'weights_matrix', 'pvalues_matrix']
 
     TS = np.loadtxt(filepath, delimiter=',')
-    recon = ConvergentCrossMappingReconstructor()
+    recon = ConvergentCrossMapping()
     G = recon.fit(TS, threshold_type='range', cutoffs=[(-np.inf, np.inf)])
     el = set(G.edges())
     res = recon.results.keys()
@@ -80,8 +80,8 @@ def test_convergent_cross_mapping():
 
 def test_partial_correlation():
     """
-    The PartialCorrelationMatrixReconstructor has many parameterizations
-    that ought to be tested differently. Otherwise, this should be 
+    The PartialCorrelationMatrix has many parameterizations
+    that ought to be tested differently. Otherwise, this should be
     equivalent to `test_graph_size`.
     """
     for resid in [True, False]:
@@ -91,7 +91,7 @@ def test_partial_correlation():
                     pass  # this shouldn't be a valid parameterization
                 else:
                     TS = np.random.random((size, 50))
-                    G = reconstruction.PartialCorrelationMatrixReconstructor().fit(
+                    G = reconstruction.PartialCorrelationMatrix().fit(
                         TS, index=index, cutoffs=[(-np.inf, np.inf)]
                     )
                     if index is None:


### PR DESCRIPTION
We decided to make some name changes before the release rather than after. In this way, these much needed changes will break our code but not anybody else's once this is out in the wild. The changes are as follows:

1. We removed "Reconstructor" from the end of each netrd/reconstruction method EXCEPT FOR BaseReconstructor and RandomReconstructor.

2. Changed NBD to NonBacktrackingSpectral

3. Changed LaplacianSpectralMethod to LaplacianSpectral (because of 2)

To reiterate: THIS COMMIT WILL BREAK YOUR CODE. However, the fix is easy, just update the names of the classes.