### PR TITLE
Test directed input in graph distances

### DIFF
--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -81,8 +81,10 @@ def test_quantum_jsd():
 
 def test_directed_input():
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="Coercing directed graph to undirected.")
-        G = nx.fast_gnp_random_graph(100, .1, directed=True)
+        warnings.filterwarnings(
+            "ignore", message="Coercing directed graph to undirected."
+        )
+        G = nx.fast_gnp_random_graph(100, 0.1, directed=True)
 
         for label, obj in distance.__dict__.items():
             if label in ['NonBacktrackingSpectral']:
@@ -106,4 +108,3 @@ def test_directed_input():
             if isinstance(obj, type) and BaseDistance in obj.__bases__:
                 dist = obj().dist(G1, G2)
                 assert dist > 0.0
-


### PR DESCRIPTION
Repeats the three generic graph distance tests on directed ER graphs, catching graph coercion warnings. See #214 (is this sufficient to resolve it?). **We should not merge this** until we've thought more about post-pypi release workflow; i.e., should we be working with master/develop branches now?