### PR TITLE
Distance classes now directly callable.

### DIFF
--- a/netrd/distance/base.py
+++ b/netrd/distance/base.py
@@ -16,6 +16,9 @@ class BaseDistance:
     def __init__(self):
         self.results = {}
 
+    def __call__(self, *args, **kwargs):
+        return self.dist(*args, **kwargs)
+
     def dist(self, G1, G2):
         """Compute distance between two graphs.
 


### PR DESCRIPTION
A small change that brings the BaseDistance class closer to the models used by sklearn.

G1 = nx.fast_gnp_random_graph(1000, 0.1)
G2 = nx.fast_gnp_random_graph(1000, 0.1)

OLD (but still possible)
```python
dist = netrd.distance.NetSimile()
D = dist.dist(G1, G2)
```

NEW
```python
dist = netrd.distance.NetSimile()
D = dist(G1, G2)
```

I think ultimately you might want to have the distance parameters (if there are any) entered during initialisation, but for now that's a lot of work to change.