### PR TITLE
 Generate PyPI description and long_description from README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis](https://img.shields.io/travis/netsiphd/netrd.svg)](
     https://travis-ci.org/netsiphd/netrd)
 
-# `netrd`: A library for network {reconstruction, distances, dynamics}
+# netrd: A library for network {reconstruction, distances, dynamics}
 
 This library provides a consistent, NetworkX-based interface to various
 utilities for graph distances, graph reconstruction from time series data, and

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,4 +1,4 @@
-``netrd``: A library for network {reconstruction, distances, dynamics}
+netrd: A library for network {reconstruction, distances, dynamics}
 ======================================================================
 
 This library provides a consistent, NetworkX-based interface to various

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,40 @@ import setuptools
 with open('requirements.txt') as file:
     requires = [line.strip() for line in file if not line.startswith('#')]
 
+with open('README.md') as fin:
+    # read the first section of README - set between the first two '#' lines -
+    # as long_description, and use the first section header as description.
+    long_description = ""
+    at_first_section = False
+    read = iter(fin.readlines())
+    for line in read:
+        if at_first_section:
+            break
+        at_first_section = line.startswith('#')
+        description = line[1:].strip()
+    long_description += line
+    for line in read:
+        if line.startswith('#'):
+            break
+        long_description += line
+    long_description = long_description.strip()
+
+
 setuptools.setup(
     name='netrd',
-    version='0.1.0',
+    version='0.1.1',
     author='NetSI 2019 Collabathon Team',
     author_email='stefanmccabe@gmail.com',
-    description='Repository of network reconstruction, distance, and simulation methods',
+    description=description,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/netsiphd/netrd',
     packages=setuptools.find_packages(),
     install_requires=requires,
-    classifiers=['Programming Language :: Python :: 3',
-                 'License :: OSI Approved :: MIT License',
-                 'Operating System :: OS Independent'],
-    extras_require={
-        'doc':  ['POT>=0.5.1'],
-    }
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+    ],
+    extras_require={'doc': ['POT>=0.5.1']},
 )

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -77,33 +77,3 @@ def test_quantum_jsd():
         dist1 = JSD.dist(G1, G2, beta=0.1, q=2)
         dist2 = JSD.dist(G2, G1, beta=0.1, q=2)
         assert np.isclose(dist1, dist2)
-
-
-def test_directed_input():
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="Coercing directed graph to undirected.")
-        G = nx.fast_gnp_random_graph(100, .1, directed=True)
-
-        for label, obj in distance.__dict__.items():
-            if label in ['NonBacktrackingSpectral']:
-                continue
-            if isinstance(obj, type) and BaseDistance in obj.__bases__:
-                dist = obj().dist(G, G)
-                assert dist == 0.0
-
-        G1 = nx.fast_gnp_random_graph(100, 0.1, directed=True)
-        G2 = nx.fast_gnp_random_graph(100, 0.1, directed=True)
-
-        for label, obj in distance.__dict__.items():
-            if label in ['NonBacktrackingSpectral']:
-                continue
-            if isinstance(obj, type) and BaseDistance in obj.__bases__:
-                dist1 = obj().dist(G1, G2)
-                dist2 = obj().dist(G2, G1)
-                assert np.isclose(dist1, dist2)
-
-        for obj in distance.__dict__.values():
-            if isinstance(obj, type) and BaseDistance in obj.__bases__:
-                dist = obj().dist(G1, G2)
-                assert dist > 0.0
-

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -77,3 +77,33 @@ def test_quantum_jsd():
         dist1 = JSD.dist(G1, G2, beta=0.1, q=2)
         dist2 = JSD.dist(G2, G1, beta=0.1, q=2)
         assert np.isclose(dist1, dist2)
+
+
+def test_directed_input():
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Coercing directed graph to undirected.")
+        G = nx.fast_gnp_random_graph(100, .1, directed=True)
+
+        for label, obj in distance.__dict__.items():
+            if label in ['NonBacktrackingSpectral']:
+                continue
+            if isinstance(obj, type) and BaseDistance in obj.__bases__:
+                dist = obj().dist(G, G)
+                assert dist == 0.0
+
+        G1 = nx.fast_gnp_random_graph(100, 0.1, directed=True)
+        G2 = nx.fast_gnp_random_graph(100, 0.1, directed=True)
+
+        for label, obj in distance.__dict__.items():
+            if label in ['NonBacktrackingSpectral']:
+                continue
+            if isinstance(obj, type) and BaseDistance in obj.__bases__:
+                dist1 = obj().dist(G1, G2)
+                dist2 = obj().dist(G2, G1)
+                assert np.isclose(dist1, dist2)
+
+        for obj in distance.__dict__.values():
+            if isinstance(obj, type) and BaseDistance in obj.__bases__:
+                dist = obj().dist(G1, G2)
+                assert dist > 0.0
+


### PR DESCRIPTION
Resolves #233. The PyPI description was sparse because we were not defining
`long_description`. Instead of writing a new `long_description`, we now use the
first section of the README to generate both `description` (the title of the
section) and `long_description`. As a side effect (we weren't sure if Markdown
was allowed in `description`), we strip the extraneous code backticks from
"netrd" in the README, and in the docs `index.rst` for consistency. We're going
to push this ASAP and bump to 1.0.1 to make sure the change takes on PyPI.