### PR TITLE
make NBD deterministic and include in test coverage

### DIFF
--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -102,7 +102,13 @@ def nbvals(graph, topk='automatic', batch=100, tol=1e-5):
         if 2 * graph.order() - 4 < batch:
             print('Using batch size {}'.format(batch))
         topk = batch
-    eigs = lambda k: sparse.linalg.eigs(matrix, k=k, return_eigenvectors=False, tol=tol)
+
+    N = matrix.shape[0]
+    v0 = np.array([1 / N for _ in range(N)])
+    eigs = lambda k: sparse.linalg.eigs(
+        matrix, k=k, v0=v0, return_eigenvectors=False, tol=tol
+    )
+
     count = 1
     while True:
         vals = eigs(topk * count)

--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -104,7 +104,7 @@ def nbvals(graph, topk='automatic', batch=100, tol=1e-5):
         topk = batch
 
     N = matrix.shape[0]
-    v0 = np.array([1 / N for _ in range(N)])
+    v0 = np.ones(N) / N
     eigs = lambda k: sparse.linalg.eigs(
         matrix, k=k, v0=v0, return_eigenvectors=False, tol=tol
     )

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -18,11 +18,9 @@ def test_same_graph():
     G = nx.karate_club_graph()
 
     for label, obj in distance.__dict__.items():
-        if label in ['NonBacktrackingSpectral']:
-            continue
         if isinstance(obj, type) and BaseDistance in obj.__bases__:
             dist = obj().dist(G, G)
-            assert dist == 0.0
+            assert np.isclose(dist, 0.0)
 
 
 def test_different_graphs():
@@ -46,8 +44,6 @@ def test_symmetry():
     G2 = nx.fast_gnp_random_graph(100, 0.1)
 
     for label, obj in distance.__dict__.items():
-        if label in ['NonBacktrackingSpectral']:
-            continue
         if isinstance(obj, type) and BaseDistance in obj.__bases__:
             dist1 = obj().dist(G1, G2)
             dist2 = obj().dist(G2, G1)
@@ -65,7 +61,7 @@ def test_quantum_jsd():
         JSD = distance.QuantumJSD()
         G = nx.karate_club_graph()
         dist = JSD.dist(G, G, beta=0.1, q=2)
-        assert dist == 0.0
+        assert np.isclose(dist, 0.0)
 
         G1 = nx.fast_gnp_random_graph(100, 0.1)
         G2 = nx.barabasi_albert_graph(100, 5)
@@ -87,18 +83,14 @@ def test_directed_input():
         G = nx.fast_gnp_random_graph(100, 0.1, directed=True)
 
         for label, obj in distance.__dict__.items():
-            if label in ['NonBacktrackingSpectral']:
-                continue
             if isinstance(obj, type) and BaseDistance in obj.__bases__:
                 dist = obj().dist(G, G)
-                assert dist == 0.0
+                assert np.isclose(dist, 0.0)
 
         G1 = nx.fast_gnp_random_graph(100, 0.1, directed=True)
         G2 = nx.fast_gnp_random_graph(100, 0.1, directed=True)
 
         for label, obj in distance.__dict__.items():
-            if label in ['NonBacktrackingSpectral']:
-                continue
             if isinstance(obj, type) and BaseDistance in obj.__bases__:
                 dist1 = obj().dist(G1, G2)
                 dist2 = obj().dist(G2, G1)


### PR DESCRIPTION
Initializes the call to `sp.sparse.linalg.eigs` with a dummy vector of 1/Ns so
that the result is deterministic for a graph. This allows us to include NBD
back in the test suite; however, there is still some minor numerical inaccuracy,
so we change `dist == 0.0` to `np.isclose(dist, 0.0)` to account for this.