### PR TITLE
Use proper normalization in Hamming

### DIFF
--- a/netrd/distance/hamming.py
+++ b/netrd/distance/hamming.py
@@ -55,9 +55,34 @@ class Hamming(BaseDistance):
         .. [1] https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.hamming.html#scipy.spatial.distance.hamming
 
         """
+
+        if G1.number_of_nodes() == G2.number_of_nodes():
+            N = G1.number_of_nodes()
+        else:
+            raise ValueError("Graphs have the same number of nodes")
+
         adj1 = nx.to_numpy_array(G1)
         adj2 = nx.to_numpy_array(G2)
-        dist = scipy.spatial.distance.hamming(adj1.flatten(), adj2.flatten())
-        self.results['dist'] = dist
-        self.results['adjacency_matrices'] = adj1, adj2
+
+        # undirected case: consider only upper triangular
+        mask = np.triu_indices(N, k=1)
+
+        # directed case: consider all but the diagonal
+        if nx.is_directed(G1) or nx.is_directed(G2):
+            new_mask = np.tril_indices(N, k=-1)
+            mask = (np.append(mask[0], new_mask[0]), np.append(mask[1], new_mask[1]))
+
+        # only if there are self-loops include the diagonal
+        # this corrects the implicit denominator of Hamming, which
+        # should be N^2 for networks with self-loops and N(N-1) for
+        # those without
+        if next(nx.selfloop_edges(G1), None) or next(nx.selfloop_edges(G2), None):
+            new_mask = np.diag_indices(N)
+            mask = (np.append(mask[0], new_mask[0]), np.append(mask[1], new_mask[1]))
+
+        dist = scipy.spatial.distance.hamming(
+            adj1[mask].flatten(), adj2[mask].flatten()
+        )
+        self.results["dist"] = dist
+        self.results["adjacency_matrices"] = adj1, adj2
         return dist

--- a/netrd/distance/hamming.py
+++ b/netrd/distance/hamming.py
@@ -76,7 +76,7 @@ class Hamming(BaseDistance):
         # this corrects the implicit denominator of Hamming, which
         # should be N^2 for networks with self-loops and N(N-1) for
         # those without
-        if next(nx.selfloop_edges(G1), None) or next(nx.selfloop_edges(G2), None):
+        if next(nx.selfloop_edges(G1), False) or next(nx.selfloop_edges(G2), False):
             new_mask = np.diag_indices(N)
             mask = (np.append(mask[0], new_mask[0]), np.append(mask[1], new_mask[1]))
 


### PR DESCRIPTION
Harrison pointed out in a comment on our paper that our Hamming implementation
has an implicit $N^2$ instead of $N(N-1)$ normalization, so it's wrong for
graphs without selfloops. This corrects that, similar to #242.

A couple of notes:

1. I think this could be a little cleaner; the fact that `np.triu_indices()` et
al return 2-tuples cramped my style a bit.
2. The fact that this and #242 exist raise concern that this normalization issue
may be present elsewhere. Perhaps we should open a checklist issue, like we have
for #245?
3. I have not applied the same correction to `HammingIpsenMikhailov`, on the
grounds that: (i) it's sufficiently different from regular `Hamming` to consider
separately, and (ii) it probably deserves a more thorough cleanup.