### PR TITLE
use defaultdict in joint_entropy calculation

### DIFF
--- a/netrd/distance/communicability_jsd.py
+++ b/netrd/distance/communicability_jsd.py
@@ -20,9 +20,8 @@ Submitted as part of the 2019 NetSI Collabathon.
 
 import networkx as nx
 import numpy as np
-import scipy as sp
 from .base import BaseDistance
-from ..utilities import threshold, ensure_undirected
+from ..utilities import entropy, ensure_undirected
 
 
 class CommunicabilityJSD(BaseDistance):
@@ -109,20 +108,13 @@ class CommunicabilityJSD(BaseDistance):
 
         P1 = lil_sigma1 / big_sigma1
         P2 = lil_sigma2 / big_sigma2
-        P0 = (P1 + P2) / 2
+        P1 = np.array(sorted(P1))
+        P2 = np.array(sorted(P2))
 
-        H1 = sp.stats.entropy(P1)
-        H2 = sp.stats.entropy(P2)
-        H0 = sp.stats.entropy(P0)
-        dist = np.sqrt(H0 - 0.5 * (H1 + H2))
+        dist = entropy.js_divergence(P1, P2)
 
         self.results['P1'] = P1
         self.results['P2'] = P2
-        self.results['P0'] = P0
-
-        self.results['entropy_1'] = H1
-        self.results['entropy_2'] = H2
-        self.results['entropy_mixture'] = H0
         self.results['dist'] = dist
 
         return dist

--- a/netrd/distance/communicability_jsd.py
+++ b/netrd/distance/communicability_jsd.py
@@ -20,8 +20,9 @@ Submitted as part of the 2019 NetSI Collabathon.
 
 import networkx as nx
 import numpy as np
+import scipy as sp
 from .base import BaseDistance
-from ..utilities import entropy, ensure_undirected
+from ..utilities import threshold, ensure_undirected
 
 
 class CommunicabilityJSD(BaseDistance):
@@ -108,13 +109,20 @@ class CommunicabilityJSD(BaseDistance):
 
         P1 = lil_sigma1 / big_sigma1
         P2 = lil_sigma2 / big_sigma2
-        P1 = np.array(sorted(P1))
-        P2 = np.array(sorted(P2))
+        P0 = (P1 + P2) / 2
 
-        dist = entropy.js_divergence(P1, P2)
+        H1 = sp.stats.entropy(P1)
+        H2 = sp.stats.entropy(P2)
+        H0 = sp.stats.entropy(P0)
+        dist = np.sqrt(H0 - 0.5 * (H1 + H2))
 
         self.results['P1'] = P1
         self.results['P2'] = P2
+        self.results['P0'] = P0
+
+        self.results['entropy_1'] = H1
+        self.results['entropy_2'] = H2
+        self.results['entropy_mixture'] = H0
         self.results['dist'] = dist
 
         return dist

--- a/netrd/utilities/entropy.py
+++ b/netrd/utilities/entropy.py
@@ -9,6 +9,7 @@ author: Chia-Hung Yang
 Submitted as part of the 2019 NetSI Collabathon.
 """
 
+from collections import defaultdict
 import numpy as np
 from scipy.stats import entropy as sp_entropy
 
@@ -74,10 +75,9 @@ def joint_entropy(data):
     """
     # Entropy is computed through summing contribution of states with
     # non-zero empirical probability in the data
-    count = dict()
+    count = defaultdict(int)
     for state in data:
         key = tuple(state)
-        count.setdefault(key, 0)
         count[key] += 1
 
     return sp_entropy(list(count.values()), base=2)


### PR DESCRIPTION
A minor change. `dict.setdefault` was being called each time in the for loop,
which is a minor performance hit. While moving it outside the loop, it was
easier (and a bit more explicit, imo) to replace it with a `defaultdict`.