### PR TITLE
drop unnecessary sklearn dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 networkx>=2.2.0
 numpy>=1.16.0
 scipy>=1.0.0
-scikit-learn>=0.18.2
 Cython>=0.29.2
 numpydoc>=0.9
 sphinx-rtd-theme>=0.4

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('README.md') as fin:
 
 setuptools.setup(
     name='netrd',
-    version='0.2.0',
+    version='0.2.1',
     author='NetSI 2019 Collabathon Team',
     author_email='stefanmccabe@gmail.com',
     description=description,


### PR DESCRIPTION
#241 removed the only time in the codebase that we actually used sklearn.