### PR TITLE
Explicitly test for and handle weighted input 

### DIFF
--- a/netrd/distance/communicability_jsd.py
+++ b/netrd/distance/communicability_jsd.py
@@ -21,7 +21,7 @@ Submitted as part of the 2019 NetSI Collabathon.
 import networkx as nx
 import numpy as np
 from .base import BaseDistance
-from ..utilities import entropy, ensure_undirected
+from ..utilities import entropy, ensure_undirected, ensure_unweighted
 
 
 class CommunicabilityJSD(BaseDistance):
@@ -85,6 +85,9 @@ class CommunicabilityJSD(BaseDistance):
 
         G1 = ensure_undirected(G1)
         G2 = ensure_undirected(G2)
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
 
         N1 = G1.number_of_nodes()
         N2 = G2.number_of_nodes()

--- a/netrd/distance/degree_divergence.py
+++ b/netrd/distance/degree_divergence.py
@@ -15,7 +15,7 @@ from collections import Counter
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
-from ..utilities import entropy
+from ..utilities import entropy, ensure_unweighted
 
 
 class DegreeDivergence(BaseDistance):
@@ -39,6 +39,9 @@ class DegreeDivergence(BaseDistance):
             the distance between `G1` and `G2`.
 
         """
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
 
         def degree_vector_histogram(graph):
             """Return the degrees in both formats.

--- a/netrd/distance/distributional_nbd.py
+++ b/netrd/distance/distributional_nbd.py
@@ -10,6 +10,7 @@ import numpy as np
 import networkx as nx
 import scipy.sparse as sp
 from scipy.spatial.distance import euclidean, chebyshev
+from ..utilities.graph import ensure_unweighted
 
 from .base import BaseDistance
 
@@ -77,6 +78,9 @@ class DistributionalNBD(BaseDistance):
             The distance between `G1` and `G2`
 
         """
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
+
         B1 = reduced_hashimoto(G1, shave=shave, sparse=sparse, **kwargs)
         B2 = reduced_hashimoto(G2, shave=shave, sparse=sparse, **kwargs)
 

--- a/netrd/distance/dk_series.py
+++ b/netrd/distance/dk_series.py
@@ -16,7 +16,7 @@ import numpy as np
 from scipy.sparse import coo_matrix
 from collections import defaultdict
 from .base import BaseDistance
-from ..utilities import entropy, ensure_undirected
+from ..utilities import entropy, ensure_undirected, ensure_unweighted
 
 
 class dkSeries(BaseDistance):
@@ -61,6 +61,9 @@ class dkSeries(BaseDistance):
 
         G1 = ensure_undirected(G1)
         G2 = ensure_undirected(G2)
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
         N = max(len(G1), len(G2))
 
         if d == 1:

--- a/netrd/distance/frobenius.py
+++ b/netrd/distance/frobenius.py
@@ -9,13 +9,14 @@ Frobenius norm between two adjacency matrices.
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
+from ..utilities.graph import ensure_unweighted
 
 
 class Frobenius(BaseDistance):
     """The Frobenius distance between their adjacency matrices."""
 
     def dist(self, G1, G2):
-        """Frobenius distance between two graphs.
+        r"""Frobenius distance between two graphs.
 
         If :math:`a_{ij}` and :math:`b_{ij}` are the two adjacency matrices
         we define
@@ -43,6 +44,10 @@ class Frobenius(BaseDistance):
         The graphs must have the same number of nodes.
 
         """
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
+
         adj1 = nx.to_numpy_array(G1)
         adj2 = nx.to_numpy_array(G2)
         dist = np.linalg.norm((adj1 - adj2))

--- a/netrd/distance/hamming.py
+++ b/netrd/distance/hamming.py
@@ -11,6 +11,7 @@ import scipy
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
+from ..utilities.graph import ensure_unweighted
 
 
 class Hamming(BaseDistance):
@@ -55,6 +56,9 @@ class Hamming(BaseDistance):
         .. [1] https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.hamming.html#scipy.spatial.distance.hamming
 
         """
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
 
         if G1.number_of_nodes() == G2.number_of_nodes():
             N = G1.number_of_nodes()

--- a/netrd/distance/hamming_ipsen_mikhailov.py
+++ b/netrd/distance/hamming_ipsen_mikhailov.py
@@ -18,6 +18,7 @@ import networkx as nx
 from .base import BaseDistance
 from scipy.optimize import fsolve
 from .ipsen_mikhailov import _im_distance
+from ..utilities.graph import ensure_unweighted
 
 
 class HammingIpsenMikhailov(BaseDistance):
@@ -78,6 +79,9 @@ class HammingIpsenMikhailov(BaseDistance):
 
         """
         N = len(G1)
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
 
         # get the adjacency matrices
         adj1 = nx.to_numpy_array(G1)

--- a/netrd/distance/ipsen_mikhailov.py
+++ b/netrd/distance/ipsen_mikhailov.py
@@ -19,6 +19,7 @@ from .base import BaseDistance
 from scipy.sparse.csgraph import laplacian
 from scipy.linalg import eigh
 from scipy.integrate import quad
+from ..utilities.graph import ensure_unweighted
 
 
 class IpsenMikhailov(BaseDistance):
@@ -57,6 +58,8 @@ class IpsenMikhailov(BaseDistance):
 
         """
         N = len(G1)
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
 
         # get the adjacency matrices
         adj1 = nx.to_numpy_array(G1)

--- a/netrd/distance/jaccard_distance.py
+++ b/netrd/distance/jaccard_distance.py
@@ -13,6 +13,7 @@ Submitted as part of the 2019 NetSI Collabathon.
 from .base import BaseDistance
 import networkx as nx
 import numpy as np
+from ..utilities import ensure_unweighted
 
 
 class JaccardDistance(BaseDistance):
@@ -48,6 +49,9 @@ class JaccardDistance(BaseDistance):
             the distance between G1 and G2.
 
         """
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
 
         e1 = set(G1.edges)
         e2 = set(G2.edges)

--- a/netrd/distance/laplacian_spectral_method.py
+++ b/netrd/distance/laplacian_spectral_method.py
@@ -15,6 +15,7 @@ Submitted as part of the 2019 NetSI Collabathon.
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
+from ..utilities.graph import ensure_unweighted
 from scipy.special import erf
 from scipy.integrate import quad
 from scipy.linalg import eigvalsh
@@ -112,6 +113,8 @@ class LaplacianSpectral(BaseDistance):
         .. [2] https://ieeexplore.ieee.org/abstract/document/7344816.
 
         """
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
         adj1 = nx.to_numpy_array(G1)
         adj2 = nx.to_numpy_array(G2)
         self.results['adjacency_matrices'] = adj1, adj2

--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -12,6 +12,7 @@ from scipy.spatial import distance_matrix
 import scipy.sparse as sparse
 from ot import emd2
 from .base import BaseDistance
+from ..utilities.graph import ensure_unweighted
 
 
 class NonBacktrackingSpectral(BaseDistance):
@@ -51,6 +52,10 @@ matrices.
             The distance between `G1` and `G2`
 
         """
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
+
         vals1 = nbvals(G1, topk, batch, tol)
         vals2 = nbvals(G2, topk, batch, tol)
         mass = lambda num: np.ones(num) / num

--- a/netrd/distance/netlsd.py
+++ b/netrd/distance/netlsd.py
@@ -13,7 +13,7 @@ import networkx as nx
 import scipy.linalg as spl
 
 from .base import BaseDistance
-from ..utilities import ensure_undirected
+from ..utilities import ensure_undirected, ensure_unweighted
 
 
 class NetLSD(BaseDistance):
@@ -64,6 +64,9 @@ class NetLSD(BaseDistance):
 
         G1 = ensure_undirected(G1)
         G2 = ensure_undirected(G2)
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
 
         lap1 = nx.normalized_laplacian_matrix(G1)
         lap2 = nx.normalized_laplacian_matrix(G2)

--- a/netrd/distance/netsimile.py
+++ b/netrd/distance/netsimile.py
@@ -17,6 +17,7 @@ from scipy.spatial.distance import canberra
 from scipy.stats import skew, kurtosis
 
 from .base import BaseDistance
+from ..utilities import ensure_undirected, ensure_unweighted
 
 
 class NetSimile(BaseDistance):
@@ -52,19 +53,10 @@ class NetSimile(BaseDistance):
                (2012)
 
         """
-        # NOTE: the measure only works for undirected
-        # graphs. For now we will silently convert a
-        # directed graph to be undirected.
-        directed_flag = False
-        if nx.is_directed(G1):
-            G1 = nx.to_undirected(G1)
-            directed_flag = True
-        if nx.is_directed(G2):
-            G2 = nx.to_undirected(G2)
-            directed_flag = True
-
-        if directed_flag:
-            warnings.warn("Coercing directed graph to undirected.", RuntimeWarning)
+        G1 = ensure_undirected(G1)
+        G2 = ensure_undirected(G2)
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
 
         # find the graph node feature matrices
         G1_node_features = feature_extraction(G1)

--- a/netrd/distance/onion_divergence.py
+++ b/netrd/distance/onion_divergence.py
@@ -18,7 +18,7 @@ import numpy as np
 import networkx as nx
 from .base import BaseDistance
 from functools import reduce
-from netrd.utilities import ensure_undirected
+from netrd.utilities import ensure_undirected, ensure_unweighted
 
 
 class OnionDivergence(BaseDistance):
@@ -61,6 +61,8 @@ class OnionDivergence(BaseDistance):
         # take the simple graph version
         G1_simple = ensure_undirected(G1)
         G2_simple = ensure_undirected(G2)
+        G1_simple = ensure_unweighted(G1_simple)
+        G2_simple = ensure_unweighted(G2_simple)
         G1_simple.remove_edges_from(nx.selfloop_edges(G1_simple))
         G2_simple.remove_edges_from(nx.selfloop_edges(G2_simple))
 

--- a/netrd/distance/polynomial_dissimilarity.py
+++ b/netrd/distance/polynomial_dissimilarity.py
@@ -17,6 +17,7 @@ Submitted as part of the 2019 NetSI Collabathon.
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
+from ..utilities.graph import ensure_unweighted
 
 
 class PolynomialDissimilarity(BaseDistance):
@@ -57,6 +58,9 @@ class PolynomialDissimilarity(BaseDistance):
                arXiv preprint arXiv:1801.07351 (2018).
 
         """
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
+
         A1 = nx.to_numpy_array(G1)
         A2 = nx.to_numpy_array(G2)
 

--- a/netrd/distance/portrait_divergence.py
+++ b/netrd/distance/portrait_divergence.py
@@ -13,6 +13,7 @@ from collections import Counter
 import numpy as np
 import networkx as nx
 from ..utilities import entropy
+from ..utilities.graph import ensure_unweighted
 
 
 class PortraitDivergence(BaseDistance):
@@ -52,6 +53,10 @@ class PortraitDivergence(BaseDistance):
         [2] https://github.com/bagrow/portrait-divergence
 
         """
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
+
         adj1 = nx.to_numpy_array(G1)
         adj2 = nx.to_numpy_array(G2)
 

--- a/netrd/distance/quantum_jsd.py
+++ b/netrd/distance/quantum_jsd.py
@@ -20,7 +20,7 @@ import networkx as nx
 import numpy as np
 from scipy.linalg import expm
 from .base import BaseDistance
-from ..utilities import ensure_undirected
+from ..utilities import ensure_undirected, ensure_unweighted
 
 
 class QuantumJSD(BaseDistance):
@@ -113,6 +113,9 @@ class QuantumJSD(BaseDistance):
 
         G1 = ensure_undirected(G1)
         G2 = ensure_undirected(G2)
+
+        G1 = ensure_unweighted(G1)
+        G2 = ensure_unweighted(G2)
 
         def density_matrix(A, beta):
             """

--- a/netrd/utilities/graph.py
+++ b/netrd/utilities/graph.py
@@ -73,6 +73,7 @@ def ensure_undirected(G):
         warnings.warn("Coercing directed graph to undirected.", RuntimeWarning)
     return G
 
+
 def ensure_unweighted(G):
     """Ensure the graph G is unweighted.
 
@@ -100,7 +101,7 @@ def ensure_unweighted(G):
     if is_weighted:
         warnings.warn("Coercing weighted graph to unweighted.", RuntimeWarning)
         for _, _, attr in H.edges(data=True):
-            #attr['weight'] = 1.0
+            # attr['weight'] = 1.0
             attr.pop('weight', None)
 
     return H

--- a/netrd/utilities/graph.py
+++ b/netrd/utilities/graph.py
@@ -72,3 +72,35 @@ def ensure_undirected(G):
         G = G.to_undirected(as_view=False)
         warnings.warn("Coercing directed graph to undirected.", RuntimeWarning)
     return G
+
+def ensure_unweighted(G):
+    """Ensure the graph G is unweighted.
+
+    If it is not, coerce it to unweighted and warn the user.
+
+    Parameters
+    ----------
+    G (networkx graph)
+        The graph to be checked
+
+    Returns
+    -------
+
+    G (nx.Graph)
+        Unweighted version of the input graph
+
+    """
+    H = G.copy()
+    is_weighted = False
+    for _, _, attr in H.edges(data=True):
+        if attr.get('weight', 1.0) != 1.0:
+            is_weighted = True
+            break
+
+    if is_weighted:
+        warnings.warn("Coercing weighted graph to unweighted.", RuntimeWarning)
+        for _, _, attr in H.edges(data=True):
+            #attr['weight'] = 1.0
+            attr.pop('weight', None)
+
+    return H

--- a/netrd/utilities/graph.py
+++ b/netrd/utilities/graph.py
@@ -91,17 +91,13 @@ def ensure_unweighted(G):
         Unweighted version of the input graph
 
     """
-    H = G.copy()
-    is_weighted = False
-    for _, _, attr in H.edges(data=True):
-        if attr.get('weight', 1.0) != 1.0:
-            is_weighted = True
-            break
 
-    if is_weighted:
-        warnings.warn("Coercing weighted graph to unweighted.", RuntimeWarning)
-        for _, _, attr in H.edges(data=True):
-            # attr['weight'] = 1.0
-            attr.pop('weight', None)
+    for _, _, attr in G.edges(data=True):
+        if not np.isclose(attr.get('weight', 1.0), 1.0):
+            H = G.__class__()
+            H.add_nodes_from(G)
+            H.add_edges_from(G.edges)
+            warnings.warn("Coercing weighted graph to unweighted.", RuntimeWarning)
+            return H
 
-    return H
+    return G

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('README.md') as fin:
 
 setuptools.setup(
     name='netrd',
-    version='0.2.0',
+    version='0.2.1',
     author='NetSI 2019 Collabathon Team',
     author_email='stefanmccabe@gmail.com',
     description=description,

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -100,3 +100,26 @@ def test_directed_input():
             if isinstance(obj, type) and BaseDistance in obj.__bases__:
                 dist = obj().dist(G1, G2)
                 assert dist > 0.0
+
+
+def test_weighted_input():
+    G1 = nx.karate_club_graph()
+    G2 = nx.karate_club_graph()
+    rand = np.random.RandomState(seed=42)
+    edge_weights = {e: rand.randint(0, 1000) for e in G2.edges}
+    nx.set_edge_attributes(G2, edge_weights, "weight")
+    assert nx.is_isomorphic(G1, G2)
+
+    for label, obj in distance.__dict__.items():
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            if isinstance(obj, type) and BaseDistance in obj.__bases__:
+                dist = obj().dist(G1, G2)
+                warning_triggered = False
+                for warning in w:
+                    if "weighted" in str(warning.message):
+                        warning_triggered = True
+                if not warning_triggered:
+                    assert not np.isclose(dist, 0.0)
+                else:
+                    assert np.isclose(dist, 0.0)


### PR DESCRIPTION
Resolves #270. This commit has a large footprint and I'm not sure it's the best
solution for the problem, but it is _a_ solution. The core changes are the
addition of an `ensure_unweighted()` function with behavior analogous to
`ensure_undirected()`, and a new test, `test_weighted_input()`. That test
compares two isomorphic graphs with different weights, and asserts that one of
two things happens:

1. the distance function does not return zero, or
2. the distance function does return zero **and** emits a `RuntimeWarning`
generated by `ensure_unweighted()`.

The downside of this approach is in the fact that all distances that do not
support weighted graphs must add this function, which means a lot of repeated
code and increase possibility of users encountering warnings. To the first, a
decorator would be a natural next step. To the second, a solution would be
subclassing, maybe?