### PR TITLE
Replace earthmover's distance implementation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,5 +16,3 @@ python:
     - requirements: requirements.txt
     - method: pip
       path: .
-      extra_requirements:
-        - doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ install:
   - pip install --upgrade pip
   - pip install .
   - pip install -r requirements.txt
-  - pip install POT
   - if [ $TRAVIS_PYTHON_VERSION == 3.6 ] || [ $TRAVIS_PYTHON_VERSION == 3.7 ]; then pip install black; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then pip install pytest; fi
 before_script: cd tests/

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ cd netrd
 pip install .
 ```
 
-Aside from NetworkX and the Python scientific computing stack, this library also
-has dependencies on Cython and [POT](https://github.com/rflamary/POT).
-
 # Usage
 
 ## Reconstructing a graph

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,10 +17,6 @@ Installation
    cd netrd
    pip install .
 
-Aside from NetworkX and the Python scientific computing stack, this
-library also has dependencies on Cython and
-`POT <https://github.com/rflamary/POT>`__.
-
 Tutorial
 ========
 

--- a/netrd/distance/__init__.py
+++ b/netrd/distance/__init__.py
@@ -18,15 +18,7 @@ from .communicability_jsd import CommunicabilityJSD
 from .distributional_nbd import DistributionalNBD
 from .dk_series import dkSeries
 from .dmeasure import DMeasure
-
-nbd = False
-try:
-    from .nbd import NonBacktrackingSpectral
-
-    nbd = True
-except ImportError as e:
-    pass
-
+from .nbd import NonBacktrackingSpectral
 
 __all__ = [
     'Hamming',
@@ -48,7 +40,5 @@ __all__ = [
     'DistributionalNBD',
     'dkSeries',
     'DMeasure',
+    'NonBacktrackingSpectral',
 ]
-
-if nbd:
-    __all__ += ['NonBacktrackingSpectral']

--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -8,10 +8,10 @@ Non-backtracking spectral distance between two graphs.
 
 import numpy as np
 import networkx as nx
-from scipy.spatial import distance_matrix
 import scipy.sparse as sparse
-from ot import emd2
 from .base import BaseDistance
+from collections import defaultdict, Counter
+from ortools.linear_solver import pywraplp
 
 
 class NonBacktrackingSpectral(BaseDistance):
@@ -51,11 +51,15 @@ matrices.
             The distance between `G1` and `G2`
 
         """
+
         vals1 = nbvals(G1, topk, batch, tol)
         vals2 = nbvals(G2, topk, batch, tol)
-        mass = lambda num: np.ones(num) / num
-        vals_dist = distance_matrix(vals1, vals2)
-        dist = emd2(mass(vals1.shape[0]), mass(vals2.shape[0]), vals_dist)
+
+        vals1 = [tuple(vals1[i]) for i in range(len(vals1))]
+        vals2 = [tuple(vals2[i]) for i in range(len(vals2))]
+
+        dist = earthmover_distance(vals1, vals2)
+
         self.results['vals'] = (vals1, vals2)
         return dist
 
@@ -269,3 +273,81 @@ def half_incidence(graph, ordering='blocks', return_ordering=False):
         return src, tgt, func
     else:
         return src, tgt
+
+
+def euclidean_distance(x, y):
+    return np.sqrt(sum((a - b)**2 for (a, b) in zip(x, y)))
+
+def earthmover_distance(p1, p2):
+    '''
+    Jeremy Kun's MIT-licensed (see below) implementation of the Earthmover's Distance.
+
+    See <https://github.com/j2kun/earthmover>.
+
+    Arguments:
+     - p1: an iterable of hashable iterables of numbers (i.e., list of tuples)
+     - p2: an iterable of hashable iterables of numbers (i.e., list of tuples)
+
+    '''
+    dist1 = {x: float(count) / len(p1) for (x, count) in Counter(p1).items()}
+    dist2 = {x: float(count) / len(p2) for (x, count) in Counter(p2).items()}
+    solver = pywraplp.Solver('earthmover_distance', pywraplp.Solver.GLOP_LINEAR_PROGRAMMING)
+
+    variables = dict()
+
+    # for each pile in dist1, the constraint that says all the dirt must leave this pile
+    dirt_leaving_constraints = defaultdict(lambda: 0)
+
+    # for each hole in dist2, the constraint that says this hole must be filled
+    dirt_filling_constraints = defaultdict(lambda: 0)
+
+    # the objective
+    objective = solver.Objective()
+    objective.SetMinimization()
+
+    for (x, dirt_at_x) in dist1.items():
+        for (y, capacity_of_y) in dist2.items():
+            amount_to_move_x_y = solver.NumVar(0, solver.infinity(), 'z_{%s, %s}' % (x, y))
+            variables[(x, y)] = amount_to_move_x_y
+            dirt_leaving_constraints[x] += amount_to_move_x_y
+            dirt_filling_constraints[y] += amount_to_move_x_y
+            objective.SetCoefficient(amount_to_move_x_y, euclidean_distance(x, y))
+
+    for x, linear_combination in dirt_leaving_constraints.items():
+        solver.Add(linear_combination == dist1[x])
+
+    for y, linear_combination in dirt_filling_constraints.items():
+        solver.Add(linear_combination == dist2[y])
+
+    status = solver.Solve()
+    if status not in [solver.OPTIMAL, solver.FEASIBLE]:
+        raise Exception('Unable to find feasible solution')
+
+    for ((x, y), variable) in variables.items():
+        if variable.solution_value() != 0:
+            cost = euclidean_distance(x, y) * variable.solution_value()
+
+    return objective.Value()
+
+# MIT License
+
+# Copyright (c) 2020 Jeremy Kun
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+

--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -279,7 +279,6 @@ def half_incidence(graph, ordering='blocks', return_ordering=False):
         return src, tgt
 
 
-
 def earthmover_distance(p1, p2):
     '''
     Jeremy Kun's MIT-licensed (see below) implementation of the Earthmover's Distance.
@@ -316,7 +315,6 @@ def earthmover_distance(p1, p2):
 
     def euclidean_distance(x, y):
         return np.sqrt(sum((a - b) ** 2 for (a, b) in zip(x, y)))
-
 
     dist1 = {x: float(count) / len(p1) for (x, count) in Counter(p1).items()}
     dist2 = {x: float(count) / len(p2) for (x, count) in Counter(p2).items()}
@@ -361,5 +359,3 @@ def earthmover_distance(p1, p2):
             cost = euclidean_distance(x, y) * variable.solution_value()
 
     return objective.Value()
-
-

--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -59,8 +59,8 @@ matrices.
         vals1 = nbvals(G1, topk, batch, tol)
         vals2 = nbvals(G2, topk, batch, tol)
 
-        vals1 = [tuple(vals1[i]) for i in range(len(vals1))]
-        vals2 = [tuple(vals2[i]) for i in range(len(vals2))]
+        vals1 = [tuple(v) for v in vals1]
+        vals2 = [tuple(v) for v in vals2]
 
         dist = earthmover_distance(vals1, vals2)
 

--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -279,9 +279,6 @@ def half_incidence(graph, ordering='blocks', return_ordering=False):
         return src, tgt
 
 
-def euclidean_distance(x, y):
-    return np.sqrt(sum((a - b) ** 2 for (a, b) in zip(x, y)))
-
 
 def earthmover_distance(p1, p2):
     '''
@@ -294,6 +291,33 @@ def earthmover_distance(p1, p2):
      - p2: an iterable of hashable iterables of numbers (i.e., list of tuples)
 
     '''
+
+    # MIT License
+
+    # Copyright (c) 2020 Jeremy Kun
+
+    # Permission is hereby granted, free of charge, to any person obtaining a copy
+    # of this software and associated documentation files (the "Software"), to deal
+    # in the Software without restriction, including without limitation the rights
+    # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    # copies of the Software, and to permit persons to whom the Software is
+    # furnished to do so, subject to the following conditions:
+
+    # The above copyright notice and this permission notice shall be included in all
+    # copies or substantial portions of the Software.
+
+    # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    # SOFTWARE.
+
+    def euclidean_distance(x, y):
+        return np.sqrt(sum((a - b) ** 2 for (a, b) in zip(x, y)))
+
+
     dist1 = {x: float(count) / len(p1) for (x, count) in Counter(p1).items()}
     dist2 = {x: float(count) / len(p2) for (x, count) in Counter(p2).items()}
     solver = pywraplp.Solver(
@@ -339,27 +363,3 @@ def earthmover_distance(p1, p2):
     return objective.Value()
 
 
-# This file borrows code (euclidean_distance and earthmover_distance) with the
-# following license:
-#
-# MIT License
-
-# Copyright (c) 2020 Jeremy Kun
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ numpy>=1.16.0
 scipy>=1.0.0
 scikit-learn>=0.18.2
 numpydoc>=0.9
+ortools>=6.8
 sphinx-rtd-theme>=0.4
 Sphinx==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,6 @@ networkx>=2.2.0
 numpy>=1.16.0
 scipy>=1.0.0
 scikit-learn>=0.18.2
-Cython>=0.29.2
 numpydoc>=0.9
 sphinx-rtd-theme>=0.4
 Sphinx==2.0.1
-# There is a POT dependency that we handle separately
-# POT

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numpy>=1.16.0
 scipy>=1.0.0
 scikit-learn>=0.18.2
 numpydoc>=0.9
-ortools>=6.8
+ortools>=6.7
 sphinx-rtd-theme>=0.4
 Sphinx==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('README.md') as fin:
 
 setuptools.setup(
     name='netrd',
-    version='0.2.0',
+    version='0.2.1',
     author='NetSI 2019 Collabathon Team',
     author_email='stefanmccabe@gmail.com',
     description=description,

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,4 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],
-    extras_require={'doc': ['POT>=0.5.1']},
 )


### PR DESCRIPTION
This resolves #232 and helps with #267 by replacing the POT-based earthmover's distance implementation with Jeremy Kun's newly MIT-licensed implementation based on `ortools`. His implementation is not on pypi so the relevant functions are reproduced (with the license) in `nbd.py`. This removes the Cython and POT workarounds we had in `.travis.yml` and `requirements.txt` to handle its installation. This will hopefully make for a smoother experience with test builds.