### PR TITLE
Rename TimeGrangerCausality to GrangerCausality

### DIFF
--- a/doc/source/reconstruction.rst
+++ b/doc/source/reconstruction.rst
@@ -22,6 +22,7 @@ the same general usage as above.
     netrd.reconstruction.CorrelationMatrix
     netrd.reconstruction.CorrelationSpanningTree
     netrd.reconstruction.FreeEnergyMinimization
+    netrd.reconstruction.GrangerCausality
     netrd.reconstruction.GraphicalLasso
     netrd.reconstruction.MarchenkoPastur
     netrd.reconstruction.MaximumLikelihoodEstimation
@@ -34,7 +35,6 @@ the same general usage as above.
     netrd.reconstruction.PartialCorrelationMatrix
     netrd.reconstruction.RandomReconstructor
     netrd.reconstruction.ThoulessAndersonPalmer
-    netrd.reconstruction.TimeGrangerCausality
 
 
 Reference

--- a/netrd/reconstruction/__init__.py
+++ b/netrd/reconstruction/__init__.py
@@ -13,7 +13,7 @@ from .ou_inference import OUInference
 from .graphical_lasso import GraphicalLasso
 from .marchenko_pastur import MarchenkoPastur
 from .naive_transfer_entropy import NaiveTransferEntropy
-from .time_granger_causality import TimeGrangerCausality
+from .granger_causality import GrangerCausality
 from .optimal_causation_entropy import OptimalCausationEntropy
 from .correlation_spanning_tree import CorrelationSpanningTree
 
@@ -32,7 +32,7 @@ __all__ = [
     'GraphicalLasso',
     'MarchenkoPastur',
     'NaiveTransferEntropy',
-    'TimeGrangerCausality',
+    'GrangerCausality',
     'OptimalCausationEntropy',
     'CorrelationSpanningTree',
 ]

--- a/netrd/reconstruction/granger_causality.py
+++ b/netrd/reconstruction/granger_causality.py
@@ -1,5 +1,5 @@
 """
-time_granger_causality.py
+granger_causality.py
 --------------
 
 Graph reconstruction algorithm based on [1].
@@ -21,7 +21,7 @@ from sklearn.linear_model import LinearRegression
 from ..utilities import create_graph, threshold
 
 
-class TimeGrangerCausality(BaseReconstructor):
+class GrangerCausality(BaseReconstructor):
     """Uses the Granger causality between nodes."""
 
     def fit(self, TS, lag=1, threshold_type="range", **kwargs):
@@ -65,10 +65,10 @@ class TimeGrangerCausality(BaseReconstructor):
         W = np.zeros([n, n])
 
         for i in range(n):
-            xi, yi = TimeGrangerCausality.split_data(TS[i, :], lag)
+            xi, yi = GrangerCausality.split_data(TS[i, :], lag)
 
             for j in range(n):
-                xj, yj = TimeGrangerCausality.split_data(TS[j, :], lag)
+                xj, yj = GrangerCausality.split_data(TS[j, :], lag)
                 xij = np.concatenate([xi, xj], axis=-1)
                 reg1 = LinearRegression().fit(xi, yi)
                 reg2 = LinearRegression().fit(xij, yi)


### PR DESCRIPTION
`TimeGrangerCausality` has never really made sense, but we didn't mess with it
because it was broken anyway. Now that it's good, let's fix the name.