### PR TITLE
Introduce and use decorators for graph sanitizers

### DIFF
--- a/netrd/distance/communicability_jsd.py
+++ b/netrd/distance/communicability_jsd.py
@@ -21,12 +21,14 @@ Submitted as part of the 2019 NetSI Collabathon.
 import networkx as nx
 import numpy as np
 from .base import BaseDistance
-from ..utilities import entropy, ensure_undirected, ensure_unweighted
+from ..utilities import entropy, undirected, unweighted
 
 
 class CommunicabilityJSD(BaseDistance):
     """Jensen-Shannon divergence between communicability sequences."""
 
+    @undirected
+    @unweighted
     def dist(self, G1, G2):
         r"""Compares the communicability matrix of two graphs.
 
@@ -82,12 +84,6 @@ class CommunicabilityJSD(BaseDistance):
                012319.
 
         """
-
-        G1 = ensure_undirected(G1)
-        G2 = ensure_undirected(G2)
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         N1 = G1.number_of_nodes()
         N2 = G2.number_of_nodes()

--- a/netrd/distance/degree_divergence.py
+++ b/netrd/distance/degree_divergence.py
@@ -15,12 +15,13 @@ from collections import Counter
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
-from ..utilities import entropy, ensure_unweighted
+from ..utilities import entropy, unweighted
 
 
 class DegreeDivergence(BaseDistance):
     """Compare two degree distributions."""
 
+    @unweighted
     def dist(self, G1, G2):
         """Jenson-Shannon divergence between degree distributions.
 
@@ -39,9 +40,6 @@ class DegreeDivergence(BaseDistance):
             the distance between `G1` and `G2`.
 
         """
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         def degree_vector_histogram(graph):
             """Return the degrees in both formats.

--- a/netrd/distance/deltacon.py
+++ b/netrd/distance/deltacon.py
@@ -18,12 +18,13 @@ Submitted as part of the 2019 NetSI Collabathon.
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
-from ..utilities import ensure_undirected
+from ..utilities import undirected
 
 
 class DeltaCon(BaseDistance):
     """Compare matrices related to Fast Belief Propagation."""
 
+    @undirected
     def dist(self, G1, G2, exact=True, g=None):
         """DeltaCon is based on the Matsusita between matrices created from fast
         belief propagation (FBP) on graphs G1 and G2.
@@ -69,9 +70,6 @@ class DeltaCon(BaseDistance):
 
         if not exact and g is None:
             g = N
-
-        G1 = ensure_undirected(G1)
-        G2 = ensure_undirected(G2)
 
         A1 = nx.to_numpy_array(G1)
         L1 = nx.laplacian_matrix(G1).toarray()

--- a/netrd/distance/distributional_nbd.py
+++ b/netrd/distance/distributional_nbd.py
@@ -10,7 +10,7 @@ import numpy as np
 import networkx as nx
 import scipy.sparse as sp
 from scipy.spatial.distance import euclidean, chebyshev
-from ..utilities.graph import ensure_unweighted
+from ..utilities.graph import unweighted
 
 from .base import BaseDistance
 
@@ -31,6 +31,7 @@ class DistributionalNBD(BaseDistance):
 
     VECTOR_DISTANCES = {'euclidean': euclidean, 'chebyshev': chebyshev}
 
+    @unweighted
     def dist(
         self,
         G1,
@@ -78,9 +79,6 @@ class DistributionalNBD(BaseDistance):
             The distance between `G1` and `G2`
 
         """
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
-
         B1 = reduced_hashimoto(G1, shave=shave, sparse=sparse, **kwargs)
         B2 = reduced_hashimoto(G2, shave=shave, sparse=sparse, **kwargs)
 

--- a/netrd/distance/dk_series.py
+++ b/netrd/distance/dk_series.py
@@ -16,12 +16,14 @@ import numpy as np
 from scipy.sparse import coo_matrix
 from collections import defaultdict
 from .base import BaseDistance
-from ..utilities import entropy, ensure_undirected, ensure_unweighted
+from ..utilities import entropy, undirected, unweighted
 
 
 class dkSeries(BaseDistance):
     """Compare graphs based on their :math:`dk`-series."""
 
+    @unweighted
+    @undirected
     def dist(self, G1, G2, d=2):
         r"""Compute the distance between two graphs by using the Jensen-Shannon
         divergence between the :math:`dk`-series of the graphs.
@@ -59,11 +61,6 @@ class dkSeries(BaseDistance):
 
         """
 
-        G1 = ensure_undirected(G1)
-        G2 = ensure_undirected(G2)
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
         N = max(len(G1), len(G2))
 
         if d == 1:

--- a/netrd/distance/dmeasure.py
+++ b/netrd/distance/dmeasure.py
@@ -23,12 +23,13 @@ import numpy as np
 from scipy.stats import entropy
 from .base import BaseDistance
 from ..utilities.entropy import js_divergence
-from ..utilities import ensure_undirected
+from ..utilities import undirected
 
 
 class DMeasure(BaseDistance):
     """Compare two graphs by their network node dispersion."""
 
+    @undirected
     def dist(self, G1, G2, w1=0.45, w2=0.45, w3=0.10, niter=50):
         r"""The D-Measure is a comparison of structural dissimilarities between graphs.
 
@@ -103,9 +104,6 @@ class DMeasure(BaseDistance):
 
         if sum([w1, w2, w3]) != 1:
             raise ValueError("Weights must sum to one.")
-
-        G1 = ensure_undirected(G1)
-        G2 = ensure_undirected(G2)
 
         first_term = 0
         second_term = 0

--- a/netrd/distance/frobenius.py
+++ b/netrd/distance/frobenius.py
@@ -9,12 +9,13 @@ Frobenius norm between two adjacency matrices.
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
-from ..utilities.graph import ensure_unweighted
+from ..utilities.graph import unweighted
 
 
 class Frobenius(BaseDistance):
     """The Frobenius distance between their adjacency matrices."""
 
+    @unweighted
     def dist(self, G1, G2):
         r"""Frobenius distance between two graphs.
 
@@ -44,9 +45,6 @@ class Frobenius(BaseDistance):
         The graphs must have the same number of nodes.
 
         """
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         adj1 = nx.to_numpy_array(G1)
         adj2 = nx.to_numpy_array(G2)

--- a/netrd/distance/hamming.py
+++ b/netrd/distance/hamming.py
@@ -11,12 +11,13 @@ import scipy
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
-from ..utilities.graph import ensure_unweighted
+from ..utilities import unweighted
 
 
 class Hamming(BaseDistance):
     """Entry-wise disagreement between adjacency matrices."""
 
+    @unweighted
     def dist(self, G1, G2):
         r"""The proportion of disagreeing nodes between the flattened adjacency
         matrices.
@@ -56,9 +57,6 @@ class Hamming(BaseDistance):
         .. [1] https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.hamming.html#scipy.spatial.distance.hamming
 
         """
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         if G1.number_of_nodes() == G2.number_of_nodes():
             N = G1.number_of_nodes()

--- a/netrd/distance/hamming_ipsen_mikhailov.py
+++ b/netrd/distance/hamming_ipsen_mikhailov.py
@@ -18,12 +18,13 @@ import networkx as nx
 from .base import BaseDistance
 from scipy.optimize import fsolve
 from .ipsen_mikhailov import _im_distance
-from ..utilities.graph import ensure_unweighted
+from ..utilities.graph import unweighted
 
 
 class HammingIpsenMikhailov(BaseDistance):
     """Combination of Hamming and Ipsen-Mikhailov distances."""
 
+    @unweighted
     def dist(self, G1, G2, combination_factor=1):
         """Graph distance combining local and global distances.
 
@@ -79,9 +80,6 @@ class HammingIpsenMikhailov(BaseDistance):
 
         """
         N = len(G1)
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         # get the adjacency matrices
         adj1 = nx.to_numpy_array(G1)

--- a/netrd/distance/ipsen_mikhailov.py
+++ b/netrd/distance/ipsen_mikhailov.py
@@ -19,12 +19,13 @@ from .base import BaseDistance
 from scipy.sparse.csgraph import laplacian
 from scipy.linalg import eigh
 from scipy.integrate import quad
-from ..utilities.graph import ensure_unweighted
+from ..utilities.graph import unweighted
 
 
 class IpsenMikhailov(BaseDistance):
     """Compares the spectrum of the Laplacian matrices."""
 
+    @unweighted
     def dist(self, G1, G2, hwhm=0.08):
         """Compare the spectrum ot the associated Laplacian matrices.
 
@@ -58,8 +59,6 @@ class IpsenMikhailov(BaseDistance):
 
         """
         N = len(G1)
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         # get the adjacency matrices
         adj1 = nx.to_numpy_array(G1)

--- a/netrd/distance/jaccard_distance.py
+++ b/netrd/distance/jaccard_distance.py
@@ -11,14 +11,13 @@ Submitted as part of the 2019 NetSI Collabathon.
 """
 
 from .base import BaseDistance
-import networkx as nx
-import numpy as np
-from ..utilities import ensure_unweighted
+from ..utilities import unweighted
 
 
 class JaccardDistance(BaseDistance):
     """Jaccard distance between edge sets."""
 
+    @unweighted
     def dist(self, G1, G2):
         r"""Compute the Jaccard index between two graphs.
 
@@ -49,9 +48,6 @@ class JaccardDistance(BaseDistance):
             the distance between G1 and G2.
 
         """
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         e1 = set(G1.edges)
         e2 = set(G2.edges)

--- a/netrd/distance/laplacian_spectral_method.py
+++ b/netrd/distance/laplacian_spectral_method.py
@@ -15,7 +15,7 @@ Submitted as part of the 2019 NetSI Collabathon.
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
-from ..utilities.graph import ensure_unweighted
+from ..utilities.graph import unweighted
 from scipy.special import erf
 from scipy.integrate import quad
 from scipy.linalg import eigvalsh
@@ -27,6 +27,7 @@ from scipy.sparse.linalg import eigsh
 class LaplacianSpectral(BaseDistance):
     """Flexible distance able to compare the spectrum of the Laplacian in many ways."""
 
+    @unweighted
     def dist(
         self,
         G1,
@@ -113,8 +114,6 @@ class LaplacianSpectral(BaseDistance):
         .. [2] https://ieeexplore.ieee.org/abstract/document/7344816.
 
         """
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
         adj1 = nx.to_numpy_array(G1)
         adj2 = nx.to_numpy_array(G2)
         self.results['adjacency_matrices'] = adj1, adj2

--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -12,7 +12,7 @@ import scipy.sparse as sparse
 from .base import BaseDistance
 from collections import defaultdict, Counter
 from ortools.linear_solver import pywraplp
-from ..utilities.graph import ensure_unweighted
+from ..utilities import unweighted
 
 
 class NonBacktrackingSpectral(BaseDistance):
@@ -23,6 +23,7 @@ matrices.
 
     """
 
+    @unweighted
     def dist(self, G1, G2, topk='automatic', batch=100, tol=1e-5):
         """Non-Backtracking Distance between two graphs.
 
@@ -52,9 +53,6 @@ matrices.
             The distance between `G1` and `G2`
 
         """
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         vals1 = nbvals(G1, topk, batch, tol)
         vals2 = nbvals(G2, topk, batch, tol)

--- a/netrd/distance/netlsd.py
+++ b/netrd/distance/netlsd.py
@@ -13,12 +13,14 @@ import networkx as nx
 import scipy.linalg as spl
 
 from .base import BaseDistance
-from ..utilities import ensure_undirected, ensure_unweighted
+from ..utilities import undirected, unweighted
 
 
 class NetLSD(BaseDistance):
     """Compares spectral node signature distributions."""
 
+    @undirected
+    @unweighted
     def dist(self, G1, G2, normalization=None, timescales=None):
         """NetLSD: Hearing the Shape of a Graph.
 
@@ -61,12 +63,6 @@ class NetLSD(BaseDistance):
         assert isinstance(
             normalization, str
         ), 'Normalization parameter must be of string type'
-
-        G1 = ensure_undirected(G1)
-        G2 = ensure_undirected(G2)
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         lap1 = nx.normalized_laplacian_matrix(G1)
         lap2 = nx.normalized_laplacian_matrix(G2)

--- a/netrd/distance/netsimile.py
+++ b/netrd/distance/netsimile.py
@@ -12,21 +12,22 @@ Submitted as part of the 2019 NetSI Collabathon.
 """
 import networkx as nx
 import numpy as np
-import warnings
 from scipy.spatial.distance import canberra
 from scipy.stats import skew, kurtosis
 
 from .base import BaseDistance
-from ..utilities import ensure_undirected, ensure_unweighted
+from ..utilities import undirected, unweighted
 
 
 class NetSimile(BaseDistance):
     """Compares node signature distributions."""
 
+    @undirected
+    @unweighted
     def dist(self, G1, G2):
         """A scalable approach to network similarity.
 
-        A network similarity measure based on node signature distrubtions.
+        A network similarity measure based on node signature distributions.
 
         The results dictionary includes the underlying feature matrices in
         `'feature_matrices'` and the underlying signature vectors in
@@ -53,10 +54,6 @@ class NetSimile(BaseDistance):
                (2012)
 
         """
-        G1 = ensure_undirected(G1)
-        G2 = ensure_undirected(G2)
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         # find the graph node feature matrices
         G1_node_features = feature_extraction(G1)

--- a/netrd/distance/onion_divergence.py
+++ b/netrd/distance/onion_divergence.py
@@ -18,14 +18,16 @@ import numpy as np
 import networkx as nx
 from .base import BaseDistance
 from functools import reduce
-from netrd.utilities import ensure_undirected, ensure_unweighted
+from netrd.utilities import undirected, unweighted
 
 
 class OnionDivergence(BaseDistance):
     """Compares various types of feature distributions."""
 
+    @undirected
+    @unweighted
     def dist(self, G1, G2, dist='lccm'):
-        """Jenson-Shannon divergence between the feature distributions fixed by dist.
+        """Jensen-Shannon divergence between the feature distributions fixed by dist.
 
         Assumes simple graphs.
 
@@ -59,10 +61,8 @@ class OnionDivergence(BaseDistance):
 
         """
         # take the simple graph version
-        G1_simple = ensure_undirected(G1)
-        G2_simple = ensure_undirected(G2)
-        G1_simple = ensure_unweighted(G1_simple)
-        G2_simple = ensure_unweighted(G2_simple)
+        G1_simple = G1
+        G2_simple = G2
         G1_simple.remove_edges_from(nx.selfloop_edges(G1_simple))
         G2_simple.remove_edges_from(nx.selfloop_edges(G2_simple))
 

--- a/netrd/distance/polynomial_dissimilarity.py
+++ b/netrd/distance/polynomial_dissimilarity.py
@@ -17,12 +17,13 @@ Submitted as part of the 2019 NetSI Collabathon.
 import numpy as np
 import networkx as nx
 from .base import BaseDistance
-from ..utilities.graph import ensure_unweighted
+from ..utilities import unweighted
 
 
 class PolynomialDissimilarity(BaseDistance):
     """Compares polynomials relating to the eigenvalues of the adjacency matrices."""
 
+    @unweighted
     def dist(self, G1, G2, k=5, alpha=1):
         r"""Compares the polynomials of the eigenvalue decomposition of
         two adjacency matrices.
@@ -58,8 +59,6 @@ class PolynomialDissimilarity(BaseDistance):
                arXiv preprint arXiv:1801.07351 (2018).
 
         """
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         A1 = nx.to_numpy_array(G1)
         A2 = nx.to_numpy_array(G2)

--- a/netrd/distance/portrait_divergence.py
+++ b/netrd/distance/portrait_divergence.py
@@ -12,13 +12,13 @@ from .base import BaseDistance
 from collections import Counter
 import numpy as np
 import networkx as nx
-from ..utilities import entropy
-from ..utilities.graph import ensure_unweighted
+from ..utilities import entropy, unweighted
 
 
 class PortraitDivergence(BaseDistance):
     """Compares graph portraits."""
 
+    @unweighted
     def dist(self, G1, G2, bins=None, binedges=None):
         """Distance measure based on the two graphs' "portraits".
 
@@ -53,9 +53,6 @@ class PortraitDivergence(BaseDistance):
         [2] https://github.com/bagrow/portrait-divergence
 
         """
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         adj1 = nx.to_numpy_array(G1)
         adj2 = nx.to_numpy_array(G2)

--- a/netrd/distance/quantum_jsd.py
+++ b/netrd/distance/quantum_jsd.py
@@ -20,14 +20,16 @@ import networkx as nx
 import numpy as np
 from scipy.linalg import expm
 from .base import BaseDistance
-from ..utilities import ensure_undirected, ensure_unweighted
+from ..utilities import undirected, unweighted
 
 
 class QuantumJSD(BaseDistance):
     """Compares the spectral entropies of the density matrices."""
 
+    @undirected
+    @unweighted
     def dist(self, G1, G2, beta=0.1, q=None):
-        r"""Square root of the quantum :math:`q`-Jenson-Shannon divergence between two
+        r"""Square root of the quantum :math:`q`-Jensen-Shannon divergence between two
         graphs.
 
         The generalized Jensen-Shannon divergence compares two graphs by the
@@ -110,12 +112,6 @@ class QuantumJSD(BaseDistance):
 
         if q and q >= 2:
             warnings.warn("JSD is only a metric for 0 ≤ q < 2.", RuntimeWarning)
-
-        G1 = ensure_undirected(G1)
-        G2 = ensure_undirected(G2)
-
-        G1 = ensure_unweighted(G1)
-        G2 = ensure_unweighted(G2)
 
         def density_matrix(A, beta):
             """

--- a/netrd/distance/resistance_perturbation.py
+++ b/netrd/distance/resistance_perturbation.py
@@ -9,17 +9,16 @@ author: Ryan J. Gallagher & Jessica T. Davis
 Submitted as part of the 2019 NetSI Collabathon.
 
 """
-import warnings
 import numpy as np
 import networkx as nx
-import scipy.sparse as ss
 from .base import BaseDistance
-from ..utilities import ensure_undirected
+from ..utilities import undirected
 
 
 class ResistancePerturbation(BaseDistance):
     """Compares the resistance matrices."""
 
+    @undirected
     def dist(self, G1, G2, p=2):
         r"""The p-norm of the difference between two graph resistance matrices.
 
@@ -76,10 +75,6 @@ class ResistancePerturbation(BaseDistance):
         .. [1] https://arxiv.org/abs/1605.01091v2
 
         """
-        # Coerce to undirected, if needed.
-        G1 = ensure_undirected(G1)
-        G2 = ensure_undirected(G2)
-
         # Check for connected graphs
         if not nx.is_connected(G1) or not nx.is_connected(G2):
             raise ValueError(

--- a/netrd/dynamics/branching_process.py
+++ b/netrd/dynamics/branching_process.py
@@ -18,7 +18,7 @@ import numpy as np
 
 
 class BranchingModel(BaseDynamics):
-    """A sand-pile-like brancing process."""
+    """A sand-pile-like branching process."""
 
     def __init__(self):
         self.results = {}
@@ -34,7 +34,7 @@ class BranchingModel(BaseDynamics):
         scale=0.95,
         noise=True,
     ):
-        r"""Simulate a (sand-pile-like) branching processs dynamics .
+        r"""Simulate a (sand-pile-like) branching process dynamics .
 
         The results dictionary also stores the ground truth network as
         `'ground_truth'`.

--- a/netrd/dynamics/ising_glauber.py
+++ b/netrd/dynamics/ising_glauber.py
@@ -12,18 +12,19 @@ from netrd.dynamics import BaseDynamics
 import numpy as np
 import networkx as nx
 from numpy.random import rand
-from ..utilities import ensure_unweighted
+from ..utilities import unweighted
 
 
 class IsingGlauber(BaseDynamics):
     """Ising-Glauber model."""
 
+    @unweighted
     def simulate(self, G, L, init=None, beta=2):
         r"""Simulate time series on a network from the Ising-Glauber model.
 
-        In the Ising Glauber model, each node has a binary state. At every
+        In the Ising-Glauber model, each node has a binary state. At every
         time step, nodes switch their state with certain probability. For
-        inactive nodes, this probaility is :math:`1 / (1 + e^{\beta (k -
+        inactive nodes, this probability is :math:`1 / (1 + e^{\beta (k -
         2m) / k})` where :math:`\beta` is a parameter tuning the likelihood
         of switching state, :math:`k` is degree of the node and :math:`m`
         is the number of its active neighbors; for active nodes the
@@ -47,7 +48,7 @@ class IsingGlauber(BaseDynamics):
             must have binary value (0 or 1).
 
         beta (float)
-            Inversed temperature tuning the likelihood that a node switches
+            Inverse temperature tuning the likelihood that a node switches
             its state. Default to :math:`2`.
 
         Returns
@@ -58,7 +59,6 @@ class IsingGlauber(BaseDynamics):
 
         """
 
-        G = ensure_unweighted(G)
         N = G.number_of_nodes()
         adjmat = nx.to_numpy_array(G, dtype=float)
         degs = adjmat.sum(axis=0)

--- a/netrd/dynamics/kuramoto.py
+++ b/netrd/dynamics/kuramoto.py
@@ -10,15 +10,13 @@ from .base import BaseDynamics
 import networkx as nx
 import numpy as np
 import scipy.integrate as it
-from ..utilities import ensure_unweighted
+from ..utilities import unweighted
 
 
 class Kuramoto(BaseDynamics):
     """Kuramoto model of oscillators."""
 
-    def __init__(self):
-        self.results = {}
-
+    @unweighted
     def simulate(self, G, L, dt=0.01, strength=1, phases=None, freqs=None):
         r"""Simulate Kuramoto model on a ground truth network.
 
@@ -90,7 +88,6 @@ class Kuramoto(BaseDynamics):
                https://arxiv.org/abs/1511.07139
 
         """
-        G = ensure_unweighted(G)
         A = nx.to_numpy_array(G)
         N = G.number_of_nodes()
 

--- a/netrd/dynamics/lotka_volterra.py
+++ b/netrd/dynamics/lotka_volterra.py
@@ -13,12 +13,13 @@ import numpy as np
 import networkx as nx
 from numpy.random import uniform, normal
 from scipy.integrate import ode
-from ..utilities import ensure_unweighted
+from ..utilities import unweighted
 
 
 class LotkaVolterra(BaseDynamics):
     """Lotka-Volterra dynamics of species abundance."""
 
+    @unweighted
     def simulate(
         self,
         G,
@@ -95,7 +96,7 @@ class LotkaVolterra(BaseDynamics):
 
         The deterministic dynamics is simulated through the forth-order
         Runge-Kutta method, and the stochastic one is simulated through
-        mutliplicative noise with the Euler-Maruyama method.
+        multiplicative noise with the Euler-Maruyama method.
 
         The ground-truth network, time steps and the time series can be
         found in results['ground-truth'], reuslts['time_steps'] and
@@ -103,7 +104,6 @@ class LotkaVolterra(BaseDynamics):
 
         """
 
-        G = ensure_unweighted(G)
         N = G.number_of_nodes()
         adjmat = nx.to_numpy_array(G)
 

--- a/netrd/dynamics/sherrington_kirkpatrick.py
+++ b/netrd/dynamics/sherrington_kirkpatrick.py
@@ -10,15 +10,14 @@ submitted as part of the 2019 NetSI Collabathon
 from .base import BaseDynamics
 import networkx as nx
 import numpy as np
-from ..utilities import ensure_unweighted
+from ..utilities import unweighted
 
 
 class SherringtonKirkpatrickIsing(BaseDynamics):
     """Ising model-like dynamics."""
 
-    def __init__(self):
-        self.results = {}
 
+    @unweighted
     def simulate(self, G, L, noisy=False):
         r"""Simulate Kinetic Ising model dynamics on a ground truth network.
 
@@ -59,7 +58,6 @@ class SherringtonKirkpatrickIsing(BaseDynamics):
 
         """
 
-        G = ensure_unweighted(G)
         N = G.number_of_nodes()
 
         # get transition probability matrix of G

--- a/netrd/dynamics/sherrington_kirkpatrick.py
+++ b/netrd/dynamics/sherrington_kirkpatrick.py
@@ -16,7 +16,6 @@ from ..utilities import unweighted
 class SherringtonKirkpatrickIsing(BaseDynamics):
     """Ising model-like dynamics."""
 
-
     @unweighted
     def simulate(self, G, L, noisy=False):
         r"""Simulate Kinetic Ising model dynamics on a ground truth network.

--- a/netrd/dynamics/single_unbiased_random_walker.py
+++ b/netrd/dynamics/single_unbiased_random_walker.py
@@ -13,9 +13,6 @@ import numpy as np
 class SingleUnbiasedRandomWalker(BaseDynamics):
     """Random walk dynamics."""
 
-    def __init__(self):
-        self.results = {}
-
     def simulate(self, G, L, initial_node=None):
         r"""Simulate single random-walker dynamics on a ground truth network.
 

--- a/netrd/dynamics/voter.py
+++ b/netrd/dynamics/voter.py
@@ -13,12 +13,13 @@ Submitted as part of the 2019 NetSI Collabathon.
 from netrd.dynamics import BaseDynamics
 import numpy as np
 import networkx as nx
-from ..utilities import ensure_unweighted
+from ..utilities import unweighted
 
 
 class VoterModel(BaseDynamics):
     """Voter dynamics."""
 
+    @unweighted
     def simulate(self, G, L, noise=None):
         r"""Simulate voter-model-style dynamics on a network.
 
@@ -49,8 +50,6 @@ class VoterModel(BaseDynamics):
             an :math:`N \times L` array of synthetic time series data.
 
         """
-
-        G = ensure_unweighted(G)
 
         N = G.number_of_nodes()
 

--- a/netrd/utilities/graph.py
+++ b/netrd/utilities/graph.py
@@ -9,6 +9,7 @@ author: Stefan McCabe (stefanmccabe at gmail dot com)
 Submitted as part of the 2019 NetSI Collabathon.
 
 """
+from functools import wraps
 import warnings
 import numpy as np
 import networkx as nx
@@ -74,6 +75,23 @@ def ensure_undirected(G):
     return G
 
 
+def undirected(func):
+    """
+    Decorator applying `ensure_undirected()` to all `nx.Graph`-subclassed
+    arguments of `func()`.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        args = [
+            ensure_undirected(arg) if issubclass(arg.__class__, nx.Graph) else arg
+            for arg in args
+        ]
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 def ensure_unweighted(G):
     """Ensure the graph G is unweighted.
 
@@ -93,7 +111,7 @@ def ensure_unweighted(G):
     """
 
     for _, _, attr in G.edges(data=True):
-        if not np.isclose(attr.get('weight', 1.0), 1.0):
+        if not np.isclose(attr.get("weight", 1.0), 1.0):
             H = G.__class__()
             H.add_nodes_from(G)
             H.add_edges_from(G.edges)
@@ -101,3 +119,20 @@ def ensure_unweighted(G):
             return H
 
     return G
+
+
+def unweighted(func):
+    """
+    Decorator applying `ensure_unweighted()` to all `nx.Graph`-subclassed
+    arguments of `func()`.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        args = [
+            ensure_unweighted(arg) if issubclass(arg.__class__, nx.Graph) else arg
+            for arg in args
+        ]
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/netrd/utilities/graph.py
+++ b/netrd/utilities/graph.py
@@ -77,8 +77,8 @@ def ensure_undirected(G):
 
 def undirected(func):
     """
-    Decorator applying `ensure_undirected()` to all `nx.Graph`-subclassed
-    arguments of `func()`.
+    Decorator applying ``ensure_undirected()`` to all ``nx.Graph``-subclassed
+    arguments of ``func``.
     """
 
     @wraps(func)
@@ -123,8 +123,8 @@ def ensure_unweighted(G):
 
 def unweighted(func):
     """
-    Decorator applying `ensure_unweighted()` to all `nx.Graph`-subclassed
-    arguments of `func()`.
+    Decorator applying ``ensure_unweighted()`` to all ``nx.Graph``-subclassed
+    arguments of ``func``.
     """
 
     @wraps(func)


### PR DESCRIPTION
This PR (in addition to a few cosmetic changes like cleaning up typos I
encountered) introduces two decorators, `@unweighted` and `@undirected`, that
apply the `ensure_unweighted()` and `ensure_undirected()` functions to each
positional argument to a function that is subclassed from `nx.Graph()`.