### PR TITLE
Add PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![PyPI version](https://badge.fury.io/py/netrd.svg)](https://badge.fury.io/py/netrd)
 [![ReadTheDocs](https://img.shields.io/readthedocs/netrd.svg)](
     https://netrd.readthedocs.io)
 [![Travis](https://img.shields.io/travis/netsiphd/netrd.svg)](


### PR DESCRIPTION
Just noticed there was no link to the PyPI page on the readme, so it's hard to find the current version number without clicking around.