### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/netrd/distance/deltacon.py
+++ b/netrd/distance/deltacon.py
@@ -93,7 +93,7 @@ class DeltaCon(BaseDistance):
             )
 
         def matusita_dist(X, Y):
-            r""" Return the Matusita distance
+            r"""Return the Matusita distance
 
             .. math::
 

--- a/netrd/distance/distributional_nbd.py
+++ b/netrd/distance/distributional_nbd.py
@@ -22,8 +22,8 @@ class DistributionalNBD(BaseDistance):
     Computes the distance between two graphs using the empirical spectral density
     of the non-backtracking operator.
 
-    See: 
-    "Graph Comparison via the Non-backtracking Spectrum" 
+    See:
+    "Graph Comparison via the Non-backtracking Spectrum"
     A. Mellor & A. Grusovin
     arXiv:1812.05457 / 10.1103/PhysRevE.99.052309
 
@@ -63,7 +63,7 @@ class DistributionalNBD(BaseDistance):
 
         vector_distance (str)
             The distance measure used to compare two empirical distributions.
-            Currently available are 'euclidean' and 'chebyshev', implemented 
+            Currently available are 'euclidean' and 'chebyshev', implemented
             using SciPy.
             Default: 'euclidean'
 
@@ -156,7 +156,7 @@ def pseudo_hashimoto(graph):
 
 def reduced_hashimoto(graph, shave=True, sparse=True):
     """
-    
+
 
     Parameters
     ----------
@@ -218,7 +218,7 @@ def nb_eigenvalues(B, k=None, **kwargs):
 
 def logr(r, rmax):
     """
-    Logarithm to the base r. 
+    Logarithm to the base r.
 
     NOTE:Maps zero to zero as a special case.
     """
@@ -229,7 +229,7 @@ def logr(r, rmax):
 
 
 def spectral_distribution(points, cumulative=True):
-    """ 
+    """
     Returns the distribution of complex values (in r,theta-space).
     """
 

--- a/netrd/distance/nbd.py
+++ b/netrd/distance/nbd.py
@@ -17,9 +17,9 @@ from ..utilities import unweighted
 
 class NonBacktrackingSpectral(BaseDistance):
     """Compares the empirical spectral distribution of the non-backtracking
-matrices.
+    matrices.
 
-    The eigenvalues are stored in the results dictionary.
+        The eigenvalues are stored in the results dictionary.
 
     """
 
@@ -278,7 +278,7 @@ def half_incidence(graph, ordering='blocks', return_ordering=False):
 
 
 def earthmover_distance(p1, p2):
-    '''
+    """
     Jeremy Kun's MIT-licensed (see below) implementation of the Earthmover's Distance.
 
     See <https://github.com/j2kun/earthmover>.
@@ -287,7 +287,7 @@ def earthmover_distance(p1, p2):
      - p1: an iterable of hashable iterables of numbers (i.e., list of tuples)
      - p2: an iterable of hashable iterables of numbers (i.e., list of tuples)
 
-    '''
+    """
 
     # MIT License
 

--- a/netrd/distance/netsimile.py
+++ b/netrd/distance/netsimile.py
@@ -76,15 +76,15 @@ class NetSimile(BaseDistance):
 def feature_extraction(G):
     """Node feature extraction.
 
-        Parameters
-        ----------
+    Parameters
+    ----------
 
-        G (nx.Graph): a networkx graph.
+    G (nx.Graph): a networkx graph.
 
-        Returns
-        -------
+    Returns
+    -------
 
-        node_features (float): the Nx7 matrix of node features."""
+    node_features (float): the Nx7 matrix of node features."""
 
     # necessary data structures
     node_features = np.zeros(shape=(G.number_of_nodes(), 7))

--- a/netrd/distance/quantum_jsd.py
+++ b/netrd/distance/quantum_jsd.py
@@ -32,7 +32,7 @@ class QuantumJSD(BaseDistance):
         r"""Square root of the quantum :math:`q`-Jensen-Shannon divergence between two
         graphs.
 
-        The generalized Jensen-Shannon divergence compares two graphs by the
+        The generalized Jensen-Shannon divergence compares two graphs b √(H0 - 0.5 * (H1 + H2))y the
         spectral entropies of their quantum-statistical-mechanical density
         matrices. It can be written as
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('README.md') as fin:
 
 setuptools.setup(
     name='netrd',
-    version='0.2.1',
+    version='0.2.2',
     author='NetSI 2019 Collabathon Team',
     author_email='stefanmccabe@gmail.com',
     description=description,


### PR DESCRIPTION
We're prepping the wegd replication archives, and for Reasons, we need to import the `@undirected` decorator, which is not in 0.2.1.