### PR TITLE
Refactor Travis to use miniconda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,9 @@ before_install:
     conda info -a
 install:
   - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION
-  - conda install black
+  - conda activate test-env
   - pip install -r requirements.txt
+  - pip install black
   - pip install .
 
 before_script: cd tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
     fi
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
+    conda init bash
     conda info -a
 install:
   - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION black pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,38 @@ matrix:
         - os: linux
           sudo: required
           dist: xenial
+          python: "3.6"
+
+        - os: linux
+          sudo: required
+          dist: xenial
+          python: "3.7"
+
+        - os: linux
+          sudo: required
+          dist: xenial
           python: "3.8"
+
+        - os: linux
+          sudo: required
+          dist: xenial
+          python: "3.9"
+
+        - os: osx
+          language: generic
+          python: "3.6"
+
+        - os: osx
+          language: generic
+          python: "3.7"
 
         - os: osx
           language: generic
           python: "3.8"
+
+        - os: osx
+          language: generic
+          python: "3.9"
 
 before_install:
   - |
@@ -34,5 +61,5 @@ install:
 before_script: cd tests/
 script:
   - pytest
-  - if [ $TRAVIS_PYTHON_VERSION == 3.6 ] || [ $TRAVIS_PYTHON_VERSION == 3.7 ] || [ $TRAVIS_PYTHON_VERSION == 3.8 ]; then black --skip-string-normalization --check ../netrd; fi
-  - if [ $TRAVIS_PYTHON_VERSION == 3.6 ] || [ $TRAVIS_PYTHON_VERSION == 3.7 ] || [ $TRAVIS_PYTHON_VERSION == 3.8 ]; then black --skip-string-normalization --check ../tests; fi
+  - black --skip-string-normalization --check ../netrd
+  - black --skip-string-normalization --check ../tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
     conda init bash
+    source .bashrc
     conda info -a
 install:
   - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION black pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
        brew cask install miniconda
     else
        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-       bash minconda.sh -b -p $HOME/miniconda
+       bash miniconda.sh -b -p $HOME/miniconda
        source "$HOME/miniconda/etc/profile.d/conda.sh"
        hash -r
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,9 @@ before_install:
     conda update -q conda
     conda info -a
 install:
-  - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION
+  - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION black pytest
   - conda activate test-env
   - pip install -r requirements.txt
-  - pip install black
   - pip install .
 
 before_script: cd tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,24 +18,28 @@ matrix:
 
         - os: linux
           sudo: required
-          dist: xenial
+          dist: focal
           python: "3.9"
 
         - os: osx
           language: generic
           python: "3.6"
+          env: PYVER="3.6"
 
         - os: osx
           language: generic
           python: "3.7"
+          env: PYVER="3.7"
 
         - os: osx
           language: generic
           python: "3.8"
+          env: PYVER="3.8"
 
         - os: osx
           language: generic
           python: "3.9"
+          env: PYVER="3.9"
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     conda update -q conda
     conda info -a
 install:
-  - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION -f requirements.txt
+  - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION --file requirements.txt
   - conda install black
   - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
     fi
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
-    conda init bash
+    source $(conda info --root)/etc/profile.d/conda.sh
     source .bashrc
     conda info -a
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,62 +2,32 @@ language: python
 matrix:
     include:
         - os: linux
-          python: "3.5"
-
-        - os: linux
-          python: "3.6"
-
-        - os: linux
-          sudo: required
-          dist: xenial
-          python: "3.7"
-
-        - os: linux
           sudo: required
           dist: xenial
           python: "3.8"
 
         - os: osx
           language: generic
-          python: "3.5"
-          env: PYVER="3.5.7"
-
-        - os: osx
-          language: generic
-          python: "3.6"
-          env: PYVER="3.6.9"
-
-        - os: osx
-          language: generic
-          python: "3.7"
-          env: PYVER="3.7.5"
-
-        - os: osx
-          language: generic
           python: "3.8"
-          env: PYVER="3.8.0"
 
 before_install:
   - |
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew update
-    brew install openssl readline
-    brew outdated pyenv || brew upgrade pyenv
-    brew install pyenv-virtualenv
-    pyenv install $PYVER
-    export PYENV_VERSION=$PYVER
-    export PATH="/Users/travis/.pyenv/shims:${PATH}"
-    pyenv virtualenv venv
-    source ~/.pyenv/versions/venv/bin/activate
-    python --version
+       brew cask install miniconda
+    else
+       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+       bash minconda.sh -b -p $HOME/miniconda
+       source "$HOME/miniconda/etc/profile.d/conda.sh"
+       hash -r
     fi
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+    conda info -a
 install:
-  - pip install --upgrade pip
+  - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION -f requirements.txt
+  - conda install black
   - pip install .
-  - pip install -r requirements.txt
 
-  - if [ $TRAVIS_PYTHON_VERSION == 3.6 ] || [ $TRAVIS_PYTHON_VERSION == 3.7 ] || [ $TRAVIS_PYTHON_VERSION == 3.8 ]; then pip install black; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then pip install pytest; fi
 before_script: cd tests/
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,30 +16,17 @@ matrix:
           dist: xenial
           python: "3.8"
 
-        - os: linux
-          sudo: required
-          dist: focal
-          python: "3.9"
+        - os: osx
+          language: generic
+          env: PYTHON_TRAVIS_VERSION="3.6"
 
         - os: osx
           language: generic
-          python: "3.6"
-          env: PYVER="3.6"
+          env: PYTHON_TRAVIS_VERSION="3.7"
 
         - os: osx
           language: generic
-          python: "3.7"
-          env: PYVER="3.7"
-
-        - os: osx
-          language: generic
-          python: "3.8"
-          env: PYVER="3.8"
-
-        - os: osx
-          language: generic
-          python: "3.9"
-          env: PYVER="3.9"
+          env: PYTHON_TRAVIS_VERSION="3.8"
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ before_install:
     conda update -q conda
     conda info -a
 install:
-  - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION --file requirements.txt
+  - conda create -q -n test-env python=$PYTHON_TRAVIS_VERSION
   - conda install black
+  - pip install -r requirements.txt
   - pip install .
 
 before_script: cd tests/


### PR DESCRIPTION
Resolves #301. 

This does two things:
1. Refactors the Travis workflow to use miniconda on macOS and Linux. Before, macOS used pyenv and Linux used what came on the Travis build image. Using miniconda for both makes the workflow more consistent and should be easier to debug in the future. It makes the Linux builds take slightly (1-2 minutes) longer, but the build times have always dominated by the macOS tests, and those are much faster. Consider three Travis builds:

| Build | When run      | Run time | Total time |
|-------|---------------|----------|------------|
| [667](https://travis-ci.com/github/netsiphd/netrd/builds/149544601)   | 8 months ago  | 24 min   | 46 min     |
| [709](https://travis-ci.com/github/netsiphd/netrd/builds/189559958)   | Earlier today | 24 min   | 1h 27 min  |
| [721](https://travis-ci.com/github/netsiphd/netrd/builds/189587352)   | This PR           | 9 min    | 24 min     |

2. We also drop test coverage for Python 3.5, which is at end of life. This allows us to clean up the workflow a bit, since `black` was not supported on Python 3.5.