### PR TITLE
Add flake8 to CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -31,6 +31,10 @@ jobs:
       run: |
         black --skip-string-normalization --check netrd
         black --skip-string-normalization --check tests
+    - name: Check for unused imports with flake8
+      run: |
+        flake8 --select=E401 netrd
+        flake8 --select=E401 tests
     - name: Test with pytest
       run: |
         cd tests/

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -33,8 +33,8 @@ jobs:
         black --skip-string-normalization --check tests
     - name: Check for unused imports with flake8
       run: |
-        flake8 --select=E401 netrd
-        flake8 --select=E401 tests
+        flake8 --select=F401 netrd
+        flake8 --select=F401 tests
     - name: Test with pytest
       run: |
         cd tests/

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -33,8 +33,8 @@ jobs:
         black --skip-string-normalization --check tests
     - name: Check for unused imports with flake8
       run: |
-        flake8 --select=F401 netrd
-        flake8 --select=F401 tests
+        flake8 --select=F401,F403 netrd
+        flake8 --select=F401,F403 tests
     - name: Test with pytest
       run: |
         cd tests/

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black pytest
+        pip install black pytest flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install -e .
     - name: Lint with black

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,23 @@ Once you have completed the above steps, you are ready to choose an algorithm to
    If you do not do this, our tests will likely fail and your code will not be
    merged without further changes.
 
-2. After updating your local code, the first thing to do is tell git which files
+2. We also want to make sure there are no unused imports; for that we'll use
+   [flake8](https://flake8.pycqa.org/en/latest/). This is a general-purpose
+   linter that we're using to catch unused imports and wildcard imports. You
+   can probably check these manually, but our test suite will run this command:
+
+   ```
+   # if you don't have flake8 installed on your system, just pip install:
+   # pip install flake8
+
+   flake8 --select F401,F403 netrd/
+   flake8 --select F401,F403 tests/
+   ```
+
+   And if there are any import warnings, it cause the tests to fail and will
+   have to be fixed before merging.
+
+3. After updating your local code, the first thing to do is tell git which files
    you have been working on. (This is called staging.) If you worked on a
    distance algorithm, for example, do
 
@@ -216,7 +232,7 @@ Once you have completed the above steps, you are ready to choose an algorithm to
    git add netrd/distance/<your_file> netrd/distance/__init__.py
    ```
 
-3. Next tell git to commit (or save) your changes:
+4. Next tell git to commit (or save) your changes:
 
 	```
 	git commit -m 'Write a commit message here. This will be public and
@@ -226,7 +242,7 @@ Once you have completed the above steps, you are ready to choose an algorithm to
 	implementation of SomeMethod, based on SomeAuthor and/or SomeCode.'
 	```
 
-4. Now you have to tell git to do two things. First, `pull` the latest changes from
+5. Now you have to tell git to do two things. First, `pull` the latest changes from
    the upstream repository (in case someone made changes while you were coding), 
    then `push` your changes and the updated code from your machine to your fork:
 
@@ -239,7 +255,7 @@ Once you have completed the above steps, you are ready to choose an algorithm to
 	conflicts that must be merged. If you run in to trouble here, ask
 	for help!
 
-5. Finally, you need to tell this (the upstream) repository to include your
+6. Finally, you need to tell this (the upstream) repository to include your
    contributions. For this, we use the GitHub web interface. At the top of
    this page, there is a 'New Pull Request' button. Click on it, and it
    will take you to a page titled 'Compare Changes'. Right below the title,

--- a/netrd/__init__.py
+++ b/netrd/__init__.py
@@ -9,7 +9,7 @@ Science Insitute 2019 Collabathon.
 
 """
 
-from . import distance
-from . import reconstruction
-from . import dynamics
-from . import utilities
+from . import distance  # noqa
+from . import reconstruction  # noqa
+from . import dynamics  # noqa
+from . import utilities  # noqa

--- a/netrd/distance/__init__.py
+++ b/netrd/distance/__init__.py
@@ -22,6 +22,7 @@ from .nbd import NonBacktrackingSpectral
 from .graph_diffusion import GraphDiffusion
 
 __all__ = [
+    'BaseDistance',
     'Hamming',
     'Frobenius',
     'PortraitDivergence',

--- a/netrd/dynamics/__init__.py
+++ b/netrd/dynamics/__init__.py
@@ -9,6 +9,7 @@ from .voter import VoterModel
 from .SIS import SISModel
 
 __all__ = [
+    'BaseDynamics',
     'SherringtonKirkpatrickIsing',
     'SingleUnbiasedRandomWalker',
     'Kuramoto',

--- a/netrd/reconstruction/__init__.py
+++ b/netrd/reconstruction/__init__.py
@@ -18,6 +18,7 @@ from .optimal_causation_entropy import OptimalCausationEntropy
 from .correlation_spanning_tree import CorrelationSpanningTree
 
 __all__ = [
+    'BaseReconstructor',
     'RandomReconstructor',
     'CorrelationMatrix',
     'PartialCorrelationMatrix',

--- a/netrd/reconstruction/random.py
+++ b/netrd/reconstruction/random.py
@@ -12,7 +12,6 @@ Submitted as part of the 2019 NetSI Collabathon.
 """
 
 from .base import BaseReconstructor
-import networkx as nx
 import numpy as np
 from ..utilities import create_graph, threshold
 

--- a/netrd/utilities/__init__.py
+++ b/netrd/utilities/__init__.py
@@ -6,11 +6,24 @@ Common utilities for use within ``netrd``.
 
 """
 from .threshold import threshold
-from .graph import *
-from .read import *
-from .cluster import *
-from .standardize import *
-from .entropy import *
+from .graph import (
+    create_graph,
+    ensure_undirected,
+    undirected,
+    ensure_unweighted,
+    unweighted,
+)
+from .read import read_time_series
+from .cluster import clusterGraph
+from .standardize import mean_GNP_distance
+from .entropy import (
+    js_divergence,
+    entropy_from_seq,
+    joint_entropy,
+    conditional_entropy,
+    categorized_data,
+    linear_bins,
+)
 
 __all__ = [
     'threshold',

--- a/netrd/utilities/__init__.py
+++ b/netrd/utilities/__init__.py
@@ -10,5 +10,22 @@ from .graph import *
 from .read import *
 from .cluster import *
 from .standardize import *
+from .entropy import *
 
-__all__ = []
+__all__ = [
+    'threshold',
+    'clusterGraph',
+    'js_divergence',
+    'entropy_from_seq',
+    'joint_entropy',
+    'conditional_entropy',
+    'categorized_data',
+    'linear_bins',
+    'create_graph',
+    'undirected',
+    'ensure_undirected',
+    'unweighted',
+    'ensure_unweighted',
+    'read_time_series',
+    'mean_GNP_distance',
+]

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -7,7 +7,6 @@ Test dynamics algorithms.
 """
 
 import networkx as nx
-import numpy as np
 from netrd import dynamics
 from netrd.dynamics import BaseDynamics
 


### PR DESCRIPTION
See #318.

The output of this will currently error:

```
tests/test_dynamics.py:10:1: F401 'numpy as np' imported but unused
netrd/__init__.py:12:1: F401 '.distance' imported but unused
netrd/__init__.py:13:1: F401 '.reconstruction' imported but unused
netrd/__init__.py:14:1: F401 '.dynamics' imported but unused
netrd/__init__.py:15:1: F401 '.utilities' imported but unused
netrd/utilities/__init__.py:8:1: F401 '.threshold.threshold' imported but unused
netrd/utilities/__init__.py:9:1: F401 '.graph.*' imported but unused
netrd/utilities/__init__.py:10:1: F401 '.read.*' imported but unused
netrd/utilities/__init__.py:11:1: F401 '.cluster.*' imported but unused
netrd/utilities/__init__.py:12:1: F401 '.standardize.*' imported but unused
netrd/reconstruction/__init__.py:1:1: F401 '.base.BaseReconstructor' imported but unused
netrd/reconstruction/random.py:15:1: F401 'networkx as nx' imported but unused
netrd/dynamics/__init__.py:1:1: F401 '.base.BaseDynamics' imported but unused
netrd/distance/__init__.py:1:1: F401 '.base.BaseDistance' imported but unused
```

Two of those just need fixing; for the `__init__` stuff see [this SO post](https://stackoverflow.com/questions/31079047/python-pep8-class-in-init-imported-but-not-used). Obviously, we'll want to fix those ASAP, either in this PR or in another PR we merge before this one.